### PR TITLE
maven-war-plugin version set to 2.1.1 to fix build errors with java7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>2.1-alpha-2</version>
+          <version>2.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
original issue : https://github.com/georchestra/georchestra/issues/90
