### PR TITLE
Fixing LDAP sync / hardening LDAPUtils.saveUser()

### DIFF
--- a/jeeves/src/main/java/jeeves/resources/dbms/Dbms.java
+++ b/jeeves/src/main/java/jeeves/resources/dbms/Dbms.java
@@ -25,9 +25,11 @@ package jeeves.resources.dbms;
 
 import jeeves.constants.Jeeves;
 import jeeves.utils.Log;
+
 import org.jdom.Element;
 
 import javax.sql.DataSource;
+
 import java.io.StringReader;
 import java.sql.Connection;
 import java.sql.Date;
@@ -35,6 +37,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Savepoint;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
@@ -73,7 +76,7 @@ public class Dbms
 		this.dataSource = dataSource;
 		this.url = url;
 	}
-	
+
 	//--------------------------------------------------------------------------
 	//---
 	//--- Connection methods
@@ -215,7 +218,7 @@ public class Dbms
             }
 			long start = System.currentTimeMillis();
             resultSet = stmt.executeQuery();
-			
+
             Element result = buildResponse(resultSet, formats);
 			long end = System.currentTimeMillis();
 
@@ -290,7 +293,7 @@ public class Dbms
 		}
 		finally
 		{
-			if(stmt != null) { 
+			if(stmt != null) {
 			    stmt.close();
 			}
 		}
@@ -446,7 +449,7 @@ public class Dbms
                 output = output.replaceAll(c, "");
             }
 		}
-		
+
 		return output;
 	}
 
@@ -482,16 +485,24 @@ public class Dbms
 
 		return sb.toString();
 	}
-	
+
 	/**
 	 * In case DBMS connection was not closed
-	 * due to some error, close connection on 
+	 * due to some error, close connection on
 	 * finalize.
 	 */
 	protected void finalize() {
 		disconnect();
 	}
-	
+
+    public Savepoint setSavePoint() throws SQLException {
+        return conn.setSavepoint();
+    }
+
+    public void rollbackToSavepoint(Savepoint sp) throws SQLException {
+       conn.rollback(sp);
+    }
+
 }
 
 //=============================================================================

--- a/web/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUtils.java
+++ b/web/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUtils.java
@@ -25,6 +25,7 @@ package org.fao.geonet.kernel.security.ldap;
 import jeeves.resources.dbms.Dbms;
 import jeeves.utils.Log;
 import jeeves.utils.SerialFactory;
+
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Geonet.Profile;
 import org.fao.geonet.lib.Lib;
@@ -34,7 +35,9 @@ import org.jdom.Element;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
+
 import java.sql.SQLException;
+import java.sql.Savepoint;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,14 +45,14 @@ import java.util.Map;
 public class LDAPUtils {
 	/**
 	 * Save or update an LDAP user to the local GeoNetwork database.
-	 * 
+	 *
 	 * TODO : test when a duplicate username is in the local DB and from an LDAP
 	 * Unique key constraint should return errors.
-	 * 
+	 *
 	 * @param user
 	 * @param dbms
-	 * @param serialFactory 
-	 * @throws Exception 
+	 * @param serialFactory
+	 * @throws Exception
 	 */
 	static void saveUser(LDAPUser user, Dbms dbms, SerialFactory serialFactory, boolean importPrivilegesFromLdap, boolean createNonExistingLdapGroup) throws Exception {
 		Element selectRequest = dbms.select("SELECT * FROM Users WHERE username=?", user.getUsername());
@@ -63,19 +66,19 @@ public class LDAPUtils {
 			if (Log.isDebugEnabled(Geonet.LDAP)){
 				Log.debug(Geonet.LDAP, "  - Create LDAP user " + user.getUsername() + " in local database.");
 			}
-			 
+
 			id = serialFactory.getSerial(dbms, "Users") + "";
-			
+
 			String query = "INSERT INTO Users (id, username, password, surname, name, profile, "+
 						"address, city, state, zip, country, email, organisation, kind, phone, authtype ) "+
 						"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
-			dbms.execute(query, new Integer(id), user.getUsername(), "", user.getSurname(), user.getName(), 
-					user.getProfile(), user.getAddress(), user.getCity(), user.getState(), user.getZip(), 
-					user.getCountry(), user.getEmail(), user.getOrganisation(), user.getKind(), 
+			dbms.execute(query, new Integer(id), user.getUsername(), "", user.getSurname(), user.getName(),
+					user.getProfile(), user.getAddress(), user.getCity(), user.getState(), user.getZip(),
+					user.getCountry(), user.getEmail(), user.getOrganisation(), user.getKind(),
 					user.getPhone(), LDAPConstants.LDAP_FLAG);
 		} else {
 			// Update existing LDAP user
-			
+
 			// Retrieve user id
 			Element nextIdRequest = dbms.select("SELECT id FROM Users WHERE username = ?", user.getUsername());
 			id = nextIdRequest.getChild("record").getChildText("id");
@@ -83,14 +86,14 @@ public class LDAPUtils {
 			if (Log.isDebugEnabled(Geonet.LDAP)){
 				Log.debug(Geonet.LDAP, "  - Update LDAP user " + user.getUsername() + " (" + id + ") in local database.");
 			}
-			
+
 			// User update
 			String query = "UPDATE Users SET username=?, password=?, surname=?, name=?, profile=?, address=?,"+
 						" city=?, state=?, zip=?, country=?, email=?, organisation=?, kind=?, phone=? WHERE id=?";
-			dbms.execute (query, user.getUsername(), "", user.getSurname(), user.getName(), 
-					user.getProfile(), user.getAddress(), user.getCity(), user.getState(), user.getZip(), 
+			dbms.execute (query, user.getUsername(), "", user.getSurname(), user.getName(),
+					user.getProfile(), user.getAddress(), user.getCity(), user.getState(), user.getZip(),
 					user.getCountry(), user.getEmail(), user.getOrganisation(), user.getKind(), user.getPhone(), new Integer(id));
-			
+
 			// Delete user groups
 			if (importPrivilegesFromLdap) {
 				dbms.execute("DELETE FROM UserGroups WHERE userId=?", Integer.valueOf(id));
@@ -100,51 +103,56 @@ public class LDAPUtils {
 		// Add user groups
 		if (importPrivilegesFromLdap && !Profile.ADMINISTRATOR.equals(user.getProfile())) {
 			dbms.execute("DELETE FROM UserGroups WHERE userId=?", Integer.valueOf(id));
+			Savepoint sp = null;
 			for(Map.Entry<String, String> privilege : user.getPrivileges().entries()) {
-				// Add group privileges for each groups
-				
-				// Retrieve group id
-				String groupName = privilege.getKey();
-				String profile = privilege.getValue();
-				
-				Element groupIdRequest = dbms.select("SELECT id FROM Groups WHERE name = ?", groupName);
-				Element groupRecord = groupIdRequest.getChild("record");
-				String groupId = null;
-				
-				if (groupRecord == null && createNonExistingLdapGroup) {
-                    createIfNotExist(groupName, groupId, dbms, serialFactory);
-				}
-                else if (groupRecord != null) {
-					groupId = groupRecord.getChildText("id");
-				}
-				
-				if (createNonExistingLdapGroup) {
-					if (Log.isDebugEnabled(Geonet.LDAP)){
-						Log.debug(Geonet.LDAP, "  - Add LDAP group " + groupName + " for user.");
-					}
-					
-					Update.addGroup(dbms, Integer.valueOf(id), Integer.valueOf(groupId), profile);
-					
-					try {
-						if (profile.equals(Profile.REVIEWER)) {
-							Update.addGroup(dbms, Integer.valueOf(id), Integer.valueOf(
-									groupId), Profile.EDITOR);
-						}
-					} catch (Exception e) {
-						Log.debug(Geonet.LDAP,
-								"  - User is already editor for that group."
-										+ e.getMessage());
-					}
-				} else {
-					if (Log.isDebugEnabled(Geonet.LDAP)){
-						Log.debug(Geonet.LDAP, "  - Can't create LDAP group " + groupName + " for user. " +
-												"Group does not exist in local database or createNonExistingLdapGroup is set to false.");
-					}
-				}
-			}
+			    try {
+                    sp = dbms.setSavePoint();
+                    // Add group privileges for each groups
+
+                    // Retrieve group id
+                    String groupName = privilege.getKey();
+                    String profile = privilege.getValue();
+
+                    Element groupIdRequest = dbms.select("SELECT id FROM Groups WHERE name = ?", groupName);
+                    Element groupRecord = groupIdRequest.getChild("record");
+                    String groupId = null;
+
+                    if (groupRecord == null && createNonExistingLdapGroup) {
+                        groupId = createIfNotExist(groupName, groupId, dbms, serialFactory);
+                    } else if (groupRecord != null) {
+                        groupId = groupRecord.getChildText("id");
+                    }
+
+                    if (createNonExistingLdapGroup) {
+                        if (Log.isDebugEnabled(Geonet.LDAP)) {
+                            Log.debug(Geonet.LDAP, "  - Add LDAP group " + groupName + " for user.");
+                        }
+
+                        Update.addGroup(dbms, Integer.valueOf(id), Integer.valueOf(groupId), profile);
+
+                        try {
+                            if (profile.equals(Profile.REVIEWER)) {
+                                Update.addGroup(dbms, Integer.valueOf(id), Integer.valueOf(groupId), Profile.EDITOR);
+                            }
+                        } catch (Exception e) {
+                            Log.debug(Geonet.LDAP, "  - User is already editor for that group." + e.getMessage());
+                        }
+                    } else {
+                        if (Log.isDebugEnabled(Geonet.LDAP)) {
+                            Log.debug(
+                                    Geonet.LDAP, "  - Can't create LDAP group " + groupName + " for user. "
+                                            + "Group does not exist in local database or createNonExistingLdapGroup is set to false.");
+                        }
+                    }
+			    } catch (SQLException e) {
+			        if (sp != null) {
+			            dbms.rollbackToSavepoint(sp);
+			        }
+			    }
+			} // for()
 		}
 		user.setId(id);
-		
+
 		dbms.commit();
 	}
 
@@ -156,16 +164,22 @@ public class LDAPUtils {
      * @param serialFactory
      * @throws SQLException
      */
-    protected static void createIfNotExist(String groupName, String groupId, Dbms dbms, SerialFactory serialFactory) throws SQLException {
+    protected static String createIfNotExist(String groupName, String groupId, Dbms dbms, SerialFactory serialFactory) throws SQLException {
         if (Log.isDebugEnabled(Geonet.LDAP)){
             Log.debug(Geonet.LDAP, "  - Add non existing group '" + groupName + "' in local database.");
         }
 
         // If LDAP group does not exist in local database, create it
+
+        // TODO: why passing groupId as argument if it is not actually used ?
+        // For now, we consider the LDAP server as authoritative, and the group name
+        // will be used.
         groupId = serialFactory.getSerial(dbms, "Groups") + "";
-        String query = "INSERT INTO GROUPS(id, name) VALUES(?,?)";
-        dbms.execute(query, Integer.valueOf(groupId), groupName);
+        String query = "INSERT INTO GROUPS(id, name, description) VALUES(?,?,?)";
+        dbms.execute(query, Integer.valueOf(groupId), groupName, groupName);
         Lib.local.insert(dbms, "Groups", Integer.valueOf(groupId), groupName);
+
+        return groupId;
     }
 
 	static Map<String, ArrayList<String>> convertAttributes(
@@ -175,16 +189,16 @@ public class LDAPUtils {
 			while (attributesEnumeration.hasMore()) {
 				Attribute attr = attributesEnumeration.next();
 				String id = attr.getID();
-				
+
 				ArrayList<String> values = userInfo.get(id);
 				if (values == null) {
 					values = new ArrayList<String>();
 					userInfo.put(id, values);
 				}
-				
+
 				// --- loop on all attribute's values
 				NamingEnumeration<?> valueEnum = attr.getAll();
-				
+
 				while (valueEnum.hasMore()) {
 					Object value = valueEnum.next();
 					// Only retrieve String attribute


### PR DESCRIPTION
@jesseeichar, @fgravin,

This PR aims to address 2 different problems:
- If an error occurs during LDAP sync or user's connection, the whole
  SQL transaction is aborted, so at first error, the whole process is
  discarded. Adding some checkpoints to be able to recover after an
  error (concerning user's connection, the error is related to adding a
  group into DB ; for the LDAP sync job, the error is related to
  removing a user who is still owning some metadatas).
- When a user connects a call is made to LDAPUtils.saveUser(), which
  tries to add groups if not existing. But groupId was potentially null,
  resulting of an Exception being thrown, and the user was not able to
  connect.

This has not been tested yet, but I plan to test it locally with a LDAP
dump from PIGMA.
