### PR TITLE
fix for jetty

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -266,6 +266,12 @@
     <dependency>
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
+      <exclusions> 
+        <exclusion> 
+          <groupId>com.ibm.icu</groupId> 
+          <artifactId>icu4j</artifactId> 
+        </exclusion> 
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Under Jetty, Geonetwork fail at startup with this error message : 

> java.lang.RuntimeException: Error scanning entry com/ibm/icu/impl/data/LocaleElements_zh__PINYIN.class from jar file:/opt/jetty-georchestra/work/jetty-0.0.0.0-8180-geonetwork.war-_geonetwork-any-/webapp/WEB-INF/lib/icu4j-2.6.1.jar

The solution is to exclude this Jaxen's dependency in **web/pom.xml**, after that Geonetwork start again.
