### PR TITLE
Md cache seeding

### DIFF
--- a/web-client/pom.xml
+++ b/web-client/pom.xml
@@ -44,6 +44,7 @@
 						<groupId>org.georchestra</groupId>
 						<artifactId>config</artifactId>
 						<version>${project.version}</version>
+                                                <classifier>${server}</classifier>
 				</dependency>
 			</dependencies>
 		</plugin>
@@ -569,6 +570,7 @@
 								<groupId>org.georchestra</groupId>
 								<artifactId>config</artifactId>
 								<version>${project.version}</version>
+                                                                <classifier>${server}</classifier>
 							</dependency>
 						</dependencies>
 					</plugin>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -895,6 +895,7 @@
 								<groupId>org.georchestra</groupId>
 								<artifactId>config</artifactId>
 								<version>${project.version}</version>
+                                                                <classifier>${server}</classifier>
 						</dependency>
 					</dependencies>
 				</plugin>

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -393,8 +393,12 @@ public class Geonetwork implements ApplicationHandler {
 		CatalogConfiguration.loadCatalogConfig(path, Csw.CONFIG_FILE);
 		CatalogDispatcher catalogDis = new CatalogDispatcher(new File(path,summaryConfigXmlFile), lc);
 
+        //------------------------------------------------------------------------
+        //--- initialize the Metadata Cache seeder
+
+		
 		//------------------------------------------------------------------------
-		//--- initialize catalogue services for the web
+		//--- initialize OAIPMH server
 
 		logger.info("  - Open Archive Initiative (OAI-PMH) server...");
 

--- a/web/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/web/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -580,6 +580,7 @@ public final class Geonet {
     public static final String FEEDBACK = GEONETWORK + ".feedback";
     public static final String GEOPUBLISH = GEONETWORK + ".geopublisher";
     public static final String FORMATTER = GEONETWORK + ".formatter";
+    public static final String CACHESEEDER = GEONETWORK + ".metadata.cacheseeder";
     /**
      * Services.
      */

--- a/web/src/main/java/org/fao/geonet/services/metadata/MetadataCacheSeeder.java
+++ b/web/src/main/java/org/fao/geonet/services/metadata/MetadataCacheSeeder.java
@@ -1,0 +1,266 @@
+package org.fao.geonet.services.metadata;
+
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jeeves.resources.dbms.Dbms;
+import jeeves.server.context.ServiceContext;
+import jeeves.server.resources.ResourceManager;
+import jeeves.utils.Log;
+import jeeves.utils.Xml;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.time.DateFormatUtils;
+import org.apache.commons.lang.time.DateUtils;
+import org.fao.geonet.GeonetworkDataDirectory;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.lib.Lib;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+
+public class MetadataCacheSeeder extends QuartzJobBean implements ApplicationContextAware {
+
+    /**
+     * The path on the file system where the files can be copied.
+     */
+    private String cachePath;
+    
+    /**
+     * The XSL stylesheet to be used, in the formatter context,
+     * basically the name of the directory containing the view.xsl stylesheet.
+     */
+    private String xslStylesheet;
+
+    public void setXslStylesheet(String xslStylesheet) {
+        this.xslStylesheet = xslStylesheet;
+    }
+
+    /**
+     * The full path to the XSL stylsheet.
+     */
+    private String xslPath;
+    /**
+     * Flag to control if the backup is currently running.
+     */
+    private static AtomicBoolean isRunning = new AtomicBoolean(false);
+    
+    
+    private ApplicationContext applicationContext;
+    
+    /**
+     * Constructor
+     */
+    public MetadataCacheSeeder() {}
+
+    /**
+     * The main entry point of the scheduler.
+     */
+    @Override
+    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+
+        if (isRunning.get()) {
+            Log.info(Geonet.CACHESEEDER, "Cache seeder already running. Skipping execution.");
+            return;
+        }
+
+        if (applicationContext == null) {
+            Log.error(Geonet.CACHESEEDER,"Application context is null. Be sure to configure SchedulerFactoryBean job factory property with AutowiringSpringBeanJobFactory.");
+            return;
+        }
+
+        ResourceManager resourceManager = applicationContext.getBean(ResourceManager.class);
+        Dbms dbms = null;
+        
+        // It's actually pretty hard to get a hook on jeeves managed objects from a spring object.
+        // Bypassing GN internals and doing it by hand ...
+        // anyway, the system variable is present on every georchestra's geonetwork ...
+        String userXslDir = System.getProperty(GeonetworkDataDirectory.GEONETWORK_DIR_KEY) + File.separator + "data/user_xsl/";
+        xslPath = userXslDir + xslStylesheet + "/view.xsl";
+
+        try {
+            isRunning.set(true);
+            dbms = (Dbms) resourceManager.openDirect(Geonet.Res.MAIN_DB);
+            File fCachePath = new File(cachePath);
+
+            if ((Log.isDebugEnabled(Geonet.CACHESEEDER) && !(fCachePath.exists()))) {
+                Log.debug(Geonet.CACHESEEDER, "Directory does not exist. Skipping execution.");
+                return;
+            }
+
+            String[] extensions = { "html" };
+            Iterator<File> cachedFiles = FileUtils.iterateFiles(fCachePath, extensions, false);
+            ArrayList<String> oldUuids = buildCachedUuid(cachedFiles);
+            Log.info(Geonet.CACHESEEDER, oldUuids.size() + " old cached files to check.");
+            
+            ArrayList<String> newUuids = getPublicUuids(dbms);
+            
+            // Yesterday calculation
+            Calendar cal = Calendar.getInstance();
+            cal.add(Calendar.DATE, -1);
+            Date yesterday = cal.getTime();
+            
+            // Step 1. if oldUuid not in dbUuid, remove the file
+
+            for (String curUuid : oldUuids) {
+                if (! newUuids.contains(curUuid)) {
+                    cleanUpMetadata(curUuid);
+                }
+            }
+            
+            for (String curUuid : newUuids) {
+                // Step 2. if dbUuid.html exists in cache {
+                if (new File(this.cachePath, curUuid + ".html").exists()) {
+                    //    Step 2.1 regenerate the html file if modificationDate < current date - 24h
+                    if (getMetadataChangeDate(dbms, curUuid).after(yesterday)) {
+                        if (Log.isDebugEnabled(Geonet.CACHESEEDER))
+                            Log.debug(Geonet.CACHESEEDER, String.format("Changedate for MD %s more recent than last job run, regenerating a file", curUuid));
+                        try {
+                        generateHtmlFile(dbms, curUuid);
+                        } catch (Exception e) {
+                            Log.error(Geonet.CACHESEEDER, "Error trying to generate an HTML file.", e);
+                        }
+                    } 
+                    //    Step 2.2 if modificationDate > current date - 24h, file already up to date, skipping
+                    else {
+                        if (Log.isDebugEnabled(Geonet.CACHESEEDER))
+                            Log.debug(Geonet.CACHESEEDER, String.format("Changedate for MD %s less recent than last job run, skipping.", curUuid)); 
+                    }
+                } 
+                // Step 3. else generates the HTML file                
+                else {
+                    if (Log.isDebugEnabled(Geonet.CACHESEEDER))
+                        Log.debug(Geonet.CACHESEEDER, String.format("File does not exist yet for MD %s, generating a one.", curUuid));
+                    try {
+                        generateHtmlFile(dbms, curUuid);
+                    } catch (Exception e) {
+                        Log.error(Geonet.CACHESEEDER, "Error trying to generate an HTML file.", e);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Log.error(Geonet.CACHESEEDER, "Error occured while seeding cache: ", e);
+        } finally {
+            isRunning.set(false);
+            if (dbms != null) {
+                try {
+                    resourceManager.close(Geonet.Res.MAIN_DB, dbms);
+                } catch (Exception e) {
+                    Log.info(Geonet.CACHESEEDER, "unable to close the dbms resource");
+                }
+            }
+            if (Log.isDebugEnabled(Geonet.CACHESEEDER))
+                Log.debug(Geonet.CACHESEEDER, "metadata cache seeder job ended");
+        }
+    }
+
+    private void generateHtmlFile(Dbms dbms, String curUuid) throws Exception {
+        // Does globally the same as Format.java
+        // In a more concise way.
+        
+        Element root = new Element("root");
+        Element md = Xml.loadString(getMetaData(dbms, curUuid), false);
+
+        root = root.addContent(md);
+
+        Element transformed = Xml.transform(root, xslPath);
+        FileUtils.writeStringToFile(new File(this.cachePath, curUuid + ".html"), Xml.getString(transformed));
+    }
+
+    private String getMetaData(Dbms dbms, String curUuid) throws Exception {
+        Element resp = dbms.select("SELECT data FROM metadata WHERE uuid = ? LIMIT 1; ", curUuid);
+        return resp.getChild("record").getChildText("data");
+    }
+
+    private Date getMetadataChangeDate(Dbms dbms, String curUuid) {
+        Date d = new Date();
+        try {
+            Element resp = dbms.select(
+                    "SELECT changedate FROM metadata WHERE uuid = ? LIMIT 1; ",
+                    curUuid);
+            String strDate = resp.getChild("record").getChildText("changedate");
+            String[] patterns = { DateFormatUtils.ISO_DATETIME_FORMAT
+                    .getPattern() };
+            strDate = strDate.substring(0, 19);
+            d = DateUtils.parseDate(strDate, patterns);
+        } catch (Exception e) {
+            // the main risk is to regenerate more often than planned the HTML doc.
+            Log.error(Geonet.CACHESEEDER,
+                    "Unable to get the Metadata change date (parse error), using current date.", e);
+        }
+        return d;
+    }
+
+    /**
+     * Removes a metadata which is still present in cache but no more public in the catalog.
+     * @param curUuid
+     */
+    private void cleanUpMetadata(String curUuid) {
+        try {
+            new File(this.cachePath, curUuid + ".html").delete();
+        } catch(Exception e) {
+            Log.error(Geonet.CACHESEEDER, "Unable to remove the Metadata", e);
+        }
+    }
+
+    /**
+     * Retrieves every public MD uuids.
+     * @return ArrayList an array list of strings.
+     * @throws SQLException 
+     */
+    private ArrayList<String> getPublicUuids(Dbms dbms) throws SQLException {
+        ArrayList<String> mdUuids = new ArrayList<String>();
+        // operationid = 0 (view)
+        // groupid = 1 (ALL)
+        Element resp = dbms.select("SELECT uuid FROM metadata FULL OUTER JOIN operationallowed ON metadata.id = operationallowed.metadataid WHERE (groupid = 1 AND operationid = 0"
+                + " AND schemaid IN ('iso19139.pigma', 'iso19139', 'iso19139.fra')) OR (isharvested = 'y') ; " );
+        
+        List<Element> records = (List<Element>) resp.getChildren();
+        for (Element record : records) {
+            mdUuids.add(record.getChildText("uuid"));
+        }
+        
+        return mdUuids;
+    }
+
+    private ArrayList<String> buildCachedUuid(Iterator<File> fileList) {
+        ArrayList<String> uuids = new ArrayList<String>();
+        
+        while (fileList.hasNext()) {
+            uuids.add(FilenameUtils.getBaseName(fileList.next().getAbsolutePath()));
+        }
+
+        return uuids;
+    }
+    
+    /**
+     * Sets the cache path, called internally by Spring at bean instantiation.
+     * @param cachePath
+     *            a String describing the path where the cache files can be
+     *            stored.
+     */
+    public void setCachePath(String cachePath) {
+        this.cachePath = cachePath;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext)
+            throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+}

--- a/web/src/main/webapp/WEB-INF/classes/log4j.properties
+++ b/web/src/main/webapp/WEB-INF/classes/log4j.properties
@@ -11,6 +11,7 @@ log4j.logger.geonetwork.index       = INFO
 log4j.logger.geonetwork.csw         = INFO
 log4j.logger.geonetwork.mef         = INFO
 log4j.logger.geonetwork.z3950server = INFO
+log4j.logger.geonetwork.metadata.cacheseeder = INFO
 
 ### JEEVES SETTINGS ############################################################
 

--- a/web/src/main/webapp/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webapp/WEB-INF/config-spring-geonetwork.xml
@@ -31,4 +31,33 @@
 	<bean id="MetadataRegionsDAO" class="org.fao.geonet.services.region.MetadataRegionDAO">
 		<property name="cacheAllRegionsInMemory" value="false"/>
 	</bean>
+
+    <bean name="metadataCacheSeeder" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
+        <property name="jobClass" value="org.fao.geonet.services.metadata.MetadataCacheSeeder" />
+        <property name="jobDataAsMap">
+          <map>
+            <entry key="xslStylesheet" value="pigma-static-html" />
+            <entry key="cachePath" value="/tmp/pigma-md-cache" />
+          </map>
+        </property>
+    </bean>
+
+	<bean id="metadataCacheSeederCronTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
+		<property name="jobDetail" ref="metadataCacheSeeder" />
+        <!-- runs every minutes -->
+        <property name="cronExpression" value="0 * * * * ?" />
+        <property name="startDelay" value="30000"/>
+	</bean>
+	
+	<bean class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
+        <property name="jobFactory">
+            <bean class="org.fao.geonet.util.spring.AutowiringSpringBeanJobFactory"/>
+        </property>
+        <property name="triggers">
+            <list>
+                <ref bean="metadataCacheSeederCronTrigger" />
+            </list>
+        </property>
+    </bean>
+
 </beans>


### PR DESCRIPTION
This is a feature ordered by PIGMA (région Aquitaine) ;

The main need addressed by this PR is to generate HTML documents from metadata, to improve the way they are indexed by search engines.

This has been implemented using a QuartzScheduler job and a plain old DBMS (jeeves) object. (performance even on a PIGMA catalogue copy is not an issue: it takes less than 40 seconds to generate the sitemap.xml as well as the ~3100 MD as html on my development environment. Taking into account that the process will run one time per day, I think the current performances are acceptable).

I think it can be merged with no harm in this version of GN (almost no one still use it in production anyway, and this shall not present a stability risk until the bean is defined in the configuration files).

Tested: mainly locally. Some sample results can be found here:

http://dev.pigma.org/pigma-md-cache/f1cdae80-b328-49bc-9063-a489b86b5d4f.html
http://dev.pigma.org/pigma-md-cache/f3702bb6-757b-4b05-a72d-fda0a6a6a0a9.html

(not the latest version of the XSL, but close to the actual result)

The xsl stylesheet is in PIGMA private repository (it is not rocket science to write a specific one, and should be installed as a formatter one in the datadir).
