### PR TITLE
Mapfishapp to GeoNetwork - WMC changes (georchestra/#1057)

### DIFF
--- a/web/src/main/java/org/fao/geonet/services/mef/ImportWmc.java
+++ b/web/src/main/java/org/fao/geonet/services/mef/ImportWmc.java
@@ -41,8 +41,8 @@ public class ImportWmc extends NotInReadOnlyModeService {
 
     @Override
     public Element serviceSpecificExec(Element params, ServiceContext context)  throws Exception {
-        String wmcString = Util.getParam(params, "wmc_string");
-        String wmcUrl = Util.getParam(params, "wmc_url");
+        String wmcString = Util.getParam(params, "map_string");
+        String wmcUrl = Util.getParam(params, "map_url");
         String viewerUrl = Util.getParam(params, "viewer_url");
         String groupId = Util.getParam(params, "group_id", "1");
 

--- a/web/src/main/webapp/WEB-INF/config.xml
+++ b/web/src/main/webapp/WEB-INF/config.xml
@@ -1435,7 +1435,7 @@
 			<error sheet="xml-error.xsl" contentType="application/xml; charset=UTF-8" />
 		</service>
 
-        <service name="wmc.import">
+        <service name="map.import">
             <class name=".services.mef.ImportWmc" />
             <error sheet="xml-error.xsl" contentType="application/xml; charset=UTF-8" />
         </service>

--- a/web/src/test/java/org/fao/geonet/services/mef/ImportWmcTest.java
+++ b/web/src/test/java/org/fao/geonet/services/mef/ImportWmcTest.java
@@ -78,7 +78,7 @@ public class ImportWmcTest {
         Mockito.when(userSession.getSurname()).thenReturn("Pierre");
         Mockito.when(userSession.getName()).thenReturn("Mauduit");
         Mockito.when(userSession.getOrganisation()).thenReturn("Camptocamp France SAS");
-        Mockito.when(userSession.getPhone()).thenReturn("+33.4.79.26.58.02");
+        Mockito.when(userSession.getPhone()).thenReturn("+33.1.23.45.67.89");
 
         Mockito.when(serviceContext.getHandlerContext(Mockito.anyString())).thenReturn(geonetContext);
         Mockito.when(serviceContext.getResourceManager()).thenReturn(resourceManager);
@@ -97,8 +97,8 @@ public class ImportWmcTest {
 
         Document doc = new Document();
         Element reqElem = new Element("request");
-        reqElem.addContent(new Element("wmc_string").setText(testWmcString));
-        reqElem.addContent(new Element("wmc_url").setText(testWmcUrl));
+        reqElem.addContent(new Element("map_string").setText(testWmcString));
+        reqElem.addContent(new Element("map_url").setText(testWmcUrl));
         reqElem.addContent(new Element("viewer_url").setText(testWmcViewerUrl));
         doc.addContent(reqElem);
 


### PR DESCRIPTION
To be able to remain compatible with what the GN3.0.x versions expects,
we need to change some things in the current GN2.x implementation into
geOrchestra:
- renaming wmc_\* parameters to map_*
- also removing some unneeded perso/pro details in the tests

Tests: unit tests ok/adapted consequently, need to be tested at runtime.

Note: This would also require another PR targetting mapfishapp.
See https://github.com/georchestra/georchestra/issues/1057 for the details.
