### PR TITLE
Improve wfs harvesting

### DIFF
--- a/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -70,34 +70,32 @@ import org.jdom.Text;
 import org.jdom.filter.ElementFilter;
 import org.jdom.xpath.XPath;
 
-
 //=============================================================================
-/** 
- * A OgcWxSHarvester is able to generate metadata for data and service
- * from a GetCapabilities documents. Metadata for layers are generated
- * using layer information contained in the GetCapabilities document
- * or using a xml document pointed by the metadataUrl attribute of layer
- * element.
+/**
+ * A OgcWxSHarvester is able to generate metadata for data and service from a
+ * GetCapabilities documents. Metadata for layers are generated using layer
+ * information contained in the GetCapabilities document or using a xml document
+ * pointed by the metadataUrl attribute of layer element.
  * 
- * OGC services supported are : 
+ * OGC services supported are :
  * <ul>
- * 	<li>WMS</li>
- * 	<li>WFS</li>
- * 	<li>WCS</li>
- * 	<li>WPS</li>
- * 	<li>SOS</li>
+ * <li>WMS</li>
+ * <li>WFS</li>
+ * <li>WCS</li>
+ * <li>WPS</li>
+ * <li>SOS</li>
  * </ul>
  * 
  * Metadata produced are :
  * <ul>
- * 	<li>ISO19119 for service's metadata</li>
- * 	<li>ISO19139 for data's metadata</li>
+ * <li>ISO19119 for service's metadata</li>
+ * <li>ISO19139 for data's metadata</li>
  * </ul>
  * 
- *  Note : Layer stands for "Layer" for WMS, "FeatureType" for WFS
- *  and "Coverage" for WCS.
- *  
- * <pre>  
+ * Note : Layer stands for "Layer" for WMS, "FeatureType" for WFS and "Coverage"
+ * for WCS.
+ * 
+ * <pre>
  * <nodes>
  *  <node type="ogcwxs" id="113">
  *    <site>
@@ -138,67 +136,65 @@ import org.jdom.xpath.XPath;
  * </pre>
  * 
  * @author fxprunayre
- *   
+ * 
  */
-class Harvester extends BaseAligner
-{
-	
-	
-	/** 
+class Harvester extends BaseAligner {
+
+    /**
      * Constructor
-     *  
-     * @param log		
-     * @param context		Jeeves context
-     * @param dbms 			Database
-     * @param params	Information about harvesting configuration for the node
+     * 
+     * @param log
+     * @param context
+     *            Jeeves context
+     * @param dbms
+     *            Database
+     * @param params
+     *            Information about harvesting configuration for the node
      * 
      * @return null
      */
-	public Harvester(Logger log, 
-						ServiceContext context, 
-						Dbms dbms, 
-						OgcWxSParams params) {
-		this.log    = log;
-		this.context= context;
-		this.dbms   = dbms;
-		this.params = params;
+    public Harvester(Logger log, ServiceContext context, Dbms dbms, OgcWxSParams params) {
+        this.log = log;
+        this.context = context;
+        this.dbms = dbms;
+        this.params = params;
 
-		result = new HarvestResult ();
-		
-		GeonetContext gc = (GeonetContext) context.getHandlerContext (Geonet.CONTEXT_NAME);
-		dataMan = gc.getDataManager ();
-		schemaMan = gc.getSchemamanager ();
+        result = new HarvestResult();
+
+        GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
+        dataMan = gc.getDataManager();
+        schemaMan = gc.getSchemamanager();
     }
 
-	//---------------------------------------------------------------------------
-	//---
-	//--- API methods
-	//---
-	//---------------------------------------------------------------------------
-	/** 
+    // ---------------------------------------------------------------------------
+    // ---
+    // --- API methods
+    // ---
+    // ---------------------------------------------------------------------------
+    /**
      * Start the harvesting of a WMS, WFS or WCS node.
      */
-	public HarvestResult harvest() throws Exception {
+    public HarvestResult harvest() throws Exception {
         Element xml;
 
         log.info("Retrieving remote metadata information for : " + params.name);
-        
-		// Clean all before harvest : Remove/Add mechanism
-        // If harvest failed (ie. if node unreachable), metadata will be removed, and
-        // the node will not be referenced in the catalogue until next harvesting.
-        // TODO : define a rule for UUID in order to be able to do an update operation ? 
+
+        // Clean all before harvest : Remove/Add mechanism
+        // If harvest failed (ie. if node unreachable), metadata will be
+        // removed, and
+        // the node will not be referenced in the catalogue until next
+        // harvesting.
+        // TODO : define a rule for UUID in order to be able to do an update
+        // operation ?
         UUIDMapper localUuids = new UUIDMapper(dbms, params.uuid);
 
-
         // Try to load capabilities document
-		this.capabilitiesUrl = getBaseUrl(params.url) +
-        		"SERVICE=" + params.ogctype.substring(0,3) +
-        		"&VERSION=" + params.ogctype.substring(3) +
-        		"&REQUEST=" + GETCAPABILITIES
-        		;
+        this.capabilitiesUrl = getBaseUrl(params.url) + "SERVICE=" + params.ogctype.substring(0, 3) + "&VERSION="
+                + params.ogctype.substring(3) + "&REQUEST=" + GETCAPABILITIES;
 
-        if(log.isDebugEnabled()) log.debug("GetCapabilities document: " + this.capabilitiesUrl);
-		
+        if (log.isDebugEnabled())
+            log.debug("GetCapabilities document: " + this.capabilitiesUrl);
+
         XmlRequest req = new XmlRequest();
         req.setUrl(new URL(this.capabilitiesUrl));
         req.setMethod(XmlRequest.Method.GET);
@@ -210,760 +206,760 @@ class Harvester extends BaseAligner
 
         xml = req.execute();
 
-		//-----------------------------------------------------------------------
-		//--- remove old metadata
-		for (String uuid : localUuids.getUUIDs())
-		{
-			String id = localUuids.getID (uuid);
+        // -----------------------------------------------------------------------
+        // --- remove old metadata
+        for (String uuid : localUuids.getUUIDs()) {
+            String id = localUuids.getID(uuid);
 
-            if(log.isDebugEnabled()) log.debug ("  - Removing old metadata before update with id: " + id);
+            if (log.isDebugEnabled())
+                log.debug("  - Removing old metadata before update with id: " + id);
 
-			// Remove thumbnails
-			unsetThumbnail (id);
-			
-			// Remove metadata
-			dataMan.deleteMetadata (context, dbms, id);
-			
-			result.locallyRemoved ++;
-		}
-		
-		if (result.locallyRemoved > 0)
-			dbms.commit ();
-		
+            // Remove thumbnails
+            unsetThumbnail(id);
+
+            // Remove metadata
+            dataMan.deleteMetadata(context, dbms, id);
+
+            result.locallyRemoved++;
+        }
+
+        if (result.locallyRemoved > 0)
+            dbms.commit();
+
         // Convert from GetCapabilities to ISO19119
-        addMetadata (xml);
-        
-        dbms.commit ();
-            
+        addMetadata(xml);
+
+        dbms.commit();
+
         result.totalMetadata = result.addedMetadata + result.layer;
-    
-		return result;
-	}
-	
-	
 
-	/** 
+        return result;
+    }
+
+    /**
      * Add metadata to the node for a WxS service
-     *  
-	 *  1.Use GetCapabilities Document
-	 *  2.Transform using XSLT to iso19119
-	 *  3.Loop through layers
-	 *  4.Create md for layer
-	 *  5.Add operatesOn elem with uuid
-	 *  6.Save all
-     *	
-     * @param capa      GetCapabilities document
-     *                   
+     * 
+     * 1.Use GetCapabilities Document 2.Transform using XSLT to iso19119 3.Loop
+     * through layers 4.Create md for layer 5.Add operatesOn elem with uuid
+     * 6.Save all
+     *
+     * @param capa
+     *            GetCapabilities document
+     * 
      */
-	 private void addMetadata (Element capa) throws Exception
-	 {
-		if (capa == null)
-			return;
+    private void addMetadata(Element capa) throws Exception {
+        if (capa == null)
+            return;
 
-		//--- Loading categories and groups
-		localCateg 	= new CategoryMapper (dbms);
-		localGroups = new GroupMapper (dbms);
+        // --- Loading categories and groups
+        localCateg = new CategoryMapper(dbms);
+        localGroups = new GroupMapper(dbms);
 
-		// md5 the full capabilities URL
-		String uuid = Sha1Encoder.encodeString (this.capabilitiesUrl); // is the service identifier
-		
-		//--- Loading stylesheet
-		String styleSheet = schemaMan.getSchemaDir(params.outputSchema) + 
-							Geonet.Path.CONVERT_STYLESHEETS
-							+ "/OGCWxSGetCapabilitiesto19119/" 
-							+ "/OGC"
-							+ params.ogctype.substring(0,3)
-							+ "GetCapabilities-to-ISO19119_ISO19139.xsl";
+        // md5 the full capabilities URL
+        String uuid = Sha1Encoder.encodeString(this.capabilitiesUrl); // is the
+                                                                      // service
+                                                                      // identifier
 
-         if(log.isDebugEnabled()) log.debug ("  - XSLT transformation using " + styleSheet);
-		
-		Map<String, String> param = new HashMap<String, String>();
-		param.put("lang", params.lang);
-		param.put("topic", params.topic);
-		param.put("uuid", uuid);
-		
-		Element md = Xml.transform (capa, styleSheet, param);
-		
-		String schema = dataMan.autodetectSchema (md, null); // ie. iso19139; 
+        // --- Loading stylesheet
+        String styleSheet = schemaMan.getSchemaDir(params.outputSchema) + Geonet.Path.CONVERT_STYLESHEETS
+                + "/OGCWxSGetCapabilitiesto19119/" + "/OGC" + params.ogctype.substring(0, 3)
+                + "GetCapabilities-to-ISO19119_ISO19139.xsl";
 
-		if (schema == null) {
-			log.warning("Skipping metadata with unknown schema.");
-			result.unknownSchema ++;
-		}
+        if (log.isDebugEnabled())
+            log.debug("  - XSLT transformation using " + styleSheet);
 
+        Map<String, String> param = new HashMap<String, String>();
+        param.put("lang", params.lang);
+        param.put("topic", params.topic);
+        param.put("uuid", uuid);
 
-		//--- Create metadata for layers only if user ask for
-		if (params.useLayer || params.useLayerMd) {			
-			// Load CRS
-			// TODO
-			
-			//--- Select layers, featureTypes and Coverages (for layers having no child named layer = not take group of layer into account) 
-			// and add the metadata
-			XPath xp = XPath.newInstance ("//Layer[count(./*[name(.)='Layer'])=0] | " + 
-											"//wms:Layer[count(./*[name(.)='Layer'])=0] | " +
-											"//wfs:FeatureType | " +
-											"//wcs:CoverageOfferingBrief | " +
-											"//sos:ObservationOffering");
-			xp.addNamespace("wfs", "http://www.opengis.net/wfs");
-			xp.addNamespace("wcs", "http://www.opengis.net/wcs");
-			xp.addNamespace("wms", "http://www.opengis.net/wms");
-			xp.addNamespace("sos", "http://www.opengis.net/sos/1.0");
-										
-			@SuppressWarnings("unchecked")
+        Element md = Xml.transform(capa, styleSheet, param);
+
+        String schema = dataMan.autodetectSchema(md, null); // ie. iso19139;
+
+        if (schema == null) {
+            log.warning("Skipping metadata with unknown schema.");
+            result.unknownSchema++;
+        }
+
+        // --- Create metadata for layers only if user ask for
+        if (params.useLayer || params.useLayerMd) {
+            // Load CRS
+            // TODO
+
+            // --- Select layers, featureTypes and Coverages (for layers having
+            // no child named layer = not take group of layer into account)
+            // and add the metadata
+            XPath xp = XPath.newInstance("//Layer[count(./*[name(.)='Layer'])=0] | "
+                    + "//wms:Layer[count(./*[name(.)='Layer'])=0] | " + "//wfs:FeatureType | "
+                    + "//wcs:CoverageOfferingBrief | " + "//sos:ObservationOffering");
+            xp.addNamespace("wfs", "http://www.opengis.net/wfs");
+            xp.addNamespace("wcs", "http://www.opengis.net/wcs");
+            xp.addNamespace("wms", "http://www.opengis.net/wms");
+            xp.addNamespace("sos", "http://www.opengis.net/sos/1.0");
+
+            @SuppressWarnings("unchecked")
             List<Element> layers = xp.selectNodes(capa);
-			if (layers.size()>0) {
-				log.info("  - Number of layers, featureTypes or Coverages found : " + layers.size());
-			
-				for (Element layer : layers) {
-					WxSLayerRegistry s = addLayerMetadata (layer, capa);
-					if (s != null)
-						layersRegistry.add(s);
-				}       
-				
-				// Update ISO19119 for data/service links creation (ie. operatesOn element)
-				// The editor will support that but it will make quite heavy XML.
-				md = addOperatesOnUuid (md, layersRegistry);
-			}
-		}	
+            if (layers.size() > 0) {
+                log.info("  - Number of layers, featureTypes or Coverages found : " + layers.size());
+
+                for (Element layer : layers) {
+                    WxSLayerRegistry s = addLayerMetadata(layer, capa);
+                    if (s != null)
+                        layersRegistry.add(s);
+                }
+
+                // Update ISO19119 for data/service links creation (ie.
+                // operatesOn element)
+                // The editor will support that but it will make quite heavy
+                // XML.
+                md = addOperatesOnUuid(md, layersRegistry);
+            }
+        }
 
         // Save iso19119 metadata in DB
-		log.info("  - Adding metadata for services with " + uuid);
-		DateFormat df = new SimpleDateFormat ("yyyy-MM-dd'T'HH:mm:ss");
-		Date date = new Date();
+        log.info("  - Adding metadata for services with " + uuid);
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        Date date = new Date();
 
         //
         // insert metadata
         //
         String group = null, isTemplate = null, docType = null, title = null, category = null;
         boolean ufo = false, indexImmediate = false;
-        String id = dataMan.insertMetadata(context, dbms, schema, md, context.getSerialFactory().getSerial(dbms, "Metadata"), uuid, Integer.parseInt(params.ownerId), group, params.uuid,
-                     isTemplate, docType, title, category, df.format(date), df.format(date), ufo, indexImmediate);
+        String id = dataMan.insertMetadata(context, dbms, schema, md,
+                context.getSerialFactory().getSerial(dbms, "Metadata"), uuid, Integer.parseInt(params.ownerId), group,
+                params.uuid, isTemplate, docType, title, category, df.format(date), df.format(date), ufo,
+                indexImmediate);
 
-		int iId = Integer.parseInt(id);
+        int iId = Integer.parseInt(id);
 
-         addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context, dbms, log);
-         addCategories(id, params.getCategories(), localCateg, dataMan, dbms, context, log, null);
-		
-		dataMan.setHarvestedExt(dbms, iId, params.uuid, params.url);
-		dataMan.setTemplate(dbms, iId, "n", null);
-		
-		dbms.commit();
-		//dataMan.indexMetadata(dbms, id); setTemplate update the index
-		
-		result.addedMetadata++;
-		
-		// Add Thumbnails only after metadata insertion to avoid concurrent transaction
-		// and loaded thumbnails could eventually failed anyway.
-		if (params.ogctype.startsWith("WMS") && params.createThumbnails) {
-        	for (WxSLayerRegistry layer : layersRegistry) {
-                loadThumbnail (layer);
+        addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context, dbms, log);
+        addCategories(id, params.getCategories(), localCateg, dataMan, dbms, context, log, null);
+
+        dataMan.setHarvestedExt(dbms, iId, params.uuid, params.url);
+        dataMan.setTemplate(dbms, iId, "n", null);
+
+        dbms.commit();
+        // dataMan.indexMetadata(dbms, id); setTemplate update the index
+
+        result.addedMetadata++;
+
+        // Add Thumbnails only after metadata insertion to avoid concurrent
+        // transaction
+        // and loaded thumbnails could eventually failed anyway.
+        if (params.ogctype.startsWith("WMS") && params.createThumbnails) {
+            for (WxSLayerRegistry layer : layersRegistry) {
+                loadThumbnail(layer);
             }
         }
-	}
-	
-	
-	
-	/** 
+    }
+
+    /**
      * Add OperatesOn elements on an ISO19119 metadata
-     *  
-     *  <srv:operatesOn>
-	 *		<gmd:MD_DataIdentification uuidref=""/>
-	 *	</srv:operatesOn>
-     *	
-     * @param md                    iso19119 metadata
-     * @param layersRegistry		uuid to be added as an uuidref attribute
-     *                   
+     * 
+     * <srv:operatesOn> <gmd:MD_DataIdentification uuidref=""/>
+     * </srv:operatesOn>
+     *
+     * @param md
+     *            iso19119 metadata
+     * @param layersRegistry
+     *            uuid to be added as an uuidref attribute
+     * 
      */
-	 private Element addOperatesOnUuid (Element md, List<WxSLayerRegistry> layersRegistry) {
-				
-		Namespace gmd 	= Namespace.getNamespace("gmd", "http://www.isotc211.org/2005/gmd");
-		Namespace gco 	= Namespace.getNamespace("gco", "http://www.isotc211.org/2005/gco");
-		Namespace srv 	= Namespace.getNamespace("srv", "http://www.isotc211.org/2005/srv");
+    private Element addOperatesOnUuid(Element md, List<WxSLayerRegistry> layersRegistry) {
+
+        Namespace gmd = Namespace.getNamespace("gmd", "http://www.isotc211.org/2005/gmd");
+        Namespace gco = Namespace.getNamespace("gco", "http://www.isotc211.org/2005/gco");
+        Namespace srv = Namespace.getNamespace("srv", "http://www.isotc211.org/2005/srv");
         Namespace xlink = Namespace.getNamespace("xlink", "http://www.w3.org/1999/xlink");
 
-        Element root 	= md.getChild("identificationInfo", gmd)
-							.getChild("SV_ServiceIdentification", srv);
-
+        Element root = md.getChild("identificationInfo", gmd).getChild("SV_ServiceIdentification", srv);
 
         /*
-           * TODO
-           *
-              For each queryable layer queryable = "1" et /ROOT/Capability/Request/*[name()!='getCapabilities']
-                  or queryable = "0" et /ROOT/Capability/Request/*[name()!='getCapabilities' and name!='GetFeatureInfo']
-              should do
-                  srv:coupledResource/srv:SV_CoupledResource/srv:OperationName = /ROOT/Capability/Request/child::name()
-                  srv:coupledResource/srv:SV_CoupledResource/srv:identifier = UUID of the data metadata
-                  srv:coupledResource/srv:SV_CoupledResource/gco:ScopedName = Layer/Name
-              But is this really useful in ISO19119 ?
-           */
-		
-		if (root != null) {
-            if(log.isDebugEnabled()) log.debug("  - add SV_CoupledResource and OperatesOnUuid");
-			
-			Element couplingType = root.getChild("couplingType", srv);
-			int coupledResourceIdx = root.indexOf(couplingType);
-			
-			for (WxSLayerRegistry layer : layersRegistry)
-			{
-				// Create coupled resources elements to register all layername
-				// in service metadata. This information could be used to add
-				// interactive map button when viewing service metadata.
-				Element coupledResource = new Element ("coupledResource", srv);
-				Element scr = new Element ("SV_CoupledResource", srv);
-				
-				
-				// Create operation according to service type
-				Element operation = new Element ("operationName", srv);
-				Element operationValue = new Element ("CharacterString", gco);
-				
-				if (params.ogctype.startsWith("WMS"))
-					operationValue.setText("GetMap"); 
-				else if (params.ogctype.startsWith("WFS"))
-					operationValue.setText("GetFeature");
-				else if (params.ogctype.startsWith("WCS"))
-					operationValue.setText("GetCoverage");
-				else if (params.ogctype.startsWith("SOS"))
-					operationValue.setText("GetObservation");
-				operation.addContent(operationValue);
-				
-				// Create identifier (which is the metadata identifier)
-				Element id = new Element ("identifier", srv);
-				Element idValue = new Element ("CharacterString", gco);
-				idValue.setText(layer.uuid);
-				id.addContent(idValue);
-				
-				// Create scoped name element as defined in CSW 2.0.2 ISO profil
-				// specification to link service metadata to a layer in a service.
-				Element scopedName = new Element ("ScopedName", gco);
-				scopedName.setText(layer.name);
-				
-				scr.addContent(operation);
-				scr.addContent(id);
-				scr.addContent(scopedName);
-				coupledResource.addContent(scr);
-				
-				// Add coupled resource before coupling type element
-				root.addContent(coupledResourceIdx, coupledResource);
-				
-				
-		
-				// Add operatesOn element at the end of identification section.
-				Element op = new Element ("operatesOn", srv);
-				op.setAttribute("uuidref", layer.uuid);
+         * TODO
+         * 
+         * For each queryable layer queryable = "1" et
+         * /ROOT/Capability/Request/*[name()!='getCapabilities'] or queryable =
+         * "0" et /ROOT/Capability/Request/*[name()!='getCapabilities' and
+         * name!='GetFeatureInfo'] should do
+         * srv:coupledResource/srv:SV_CoupledResource/srv:OperationName =
+         * /ROOT/Capability/Request/child::name()
+         * srv:coupledResource/srv:SV_CoupledResource/srv:identifier = UUID of
+         * the data metadata
+         * srv:coupledResource/srv:SV_CoupledResource/gco:ScopedName =
+         * Layer/Name But is this really useful in ISO19119 ?
+         */
 
-                String hRefLink =  dataMan.getSiteURL(context) + "/xml.metadata.get?uuid=" + layer.uuid;
+        if (root != null) {
+            if (log.isDebugEnabled())
+                log.debug("  - add SV_CoupledResource and OperatesOnUuid");
+
+            Element couplingType = root.getChild("couplingType", srv);
+            int coupledResourceIdx = root.indexOf(couplingType);
+
+            for (WxSLayerRegistry layer : layersRegistry) {
+                // Create coupled resources elements to register all layername
+                // in service metadata. This information could be used to add
+                // interactive map button when viewing service metadata.
+                Element coupledResource = new Element("coupledResource", srv);
+                Element scr = new Element("SV_CoupledResource", srv);
+
+                // Create operation according to service type
+                Element operation = new Element("operationName", srv);
+                Element operationValue = new Element("CharacterString", gco);
+
+                if (params.ogctype.startsWith("WMS"))
+                    operationValue.setText("GetMap");
+                else if (params.ogctype.startsWith("WFS"))
+                    operationValue.setText("GetFeature");
+                else if (params.ogctype.startsWith("WCS"))
+                    operationValue.setText("GetCoverage");
+                else if (params.ogctype.startsWith("SOS"))
+                    operationValue.setText("GetObservation");
+                operation.addContent(operationValue);
+
+                // Create identifier (which is the metadata identifier)
+                Element id = new Element("identifier", srv);
+                Element idValue = new Element("CharacterString", gco);
+                idValue.setText(layer.uuid);
+                id.addContent(idValue);
+
+                // Create scoped name element as defined in CSW 2.0.2 ISO profil
+                // specification to link service metadata to a layer in a
+                // service.
+                Element scopedName = new Element("ScopedName", gco);
+                scopedName.setText(layer.name);
+
+                scr.addContent(operation);
+                scr.addContent(id);
+                scr.addContent(scopedName);
+                coupledResource.addContent(scr);
+
+                // Add coupled resource before coupling type element
+                root.addContent(coupledResourceIdx, coupledResource);
+
+                // Add operatesOn element at the end of identification section.
+                Element op = new Element("operatesOn", srv);
+                op.setAttribute("uuidref", layer.uuid);
+
+                String hRefLink = dataMan.getSiteURL(context) + "/xml.metadata.get?uuid=" + layer.uuid;
                 op.setAttribute("href", hRefLink, xlink);
 
-				
-				root.addContent(op);
-				
-			}
-		}
+                root.addContent(op);
 
-		
-		return md;
-	}
+            }
+        }
 
-	
-	/** 
-     * Add metadata for a Layer/FeatureType/Coverage element of a GetCapabilities document.
-     * This function search for a metadataUrl element (with @type = TC211 and format = text/xml) 
-     * and try to load the XML document. 
-     * If failed, then an XSLT is used for creating metadata from the 
-     * Layer/FeatureType/Coverage element.
-     * If loaded document contain an existing uuid, metadata will not be loaded in the catalogue.
-     *  
-     * @param layer     Layer/FeatureType/Coverage element
-     * @param capa		GetCapabilities document
-     *  
-     * @return          uuid 
-     *                   
+        return md;
+    }
+
+    /**
+     * Add metadata for a Layer/FeatureType/Coverage element of a
+     * GetCapabilities document. This function search for a metadataUrl element
+     * (with @type = TC211 and format = text/xml) and try to load the XML
+     * document. If failed, then an XSLT is used for creating metadata from the
+     * Layer/FeatureType/Coverage element. If loaded document contain an
+     * existing uuid, metadata will not be loaded in the catalogue.
+     * 
+     * @param layer
+     *            Layer/FeatureType/Coverage element
+     * @param capa
+     *            GetCapabilities document
+     * 
+     * @return uuid
+     * 
      */
-	private WxSLayerRegistry addLayerMetadata (Element layer, Element capa) throws JDOMException
-	{
-		DateFormat df 		= new SimpleDateFormat ("yyyy-MM-dd'T'HH:mm:ss");
-		Date dt 			= new Date ();
-		WxSLayerRegistry reg= new WxSLayerRegistry ();
-		String schema;
-		String mdXml;
-		String date 		= df.format (dt);
-		//--- Loading stylesheet
-		String styleSheet 	= schemaMan.getSchemaDir(params.outputSchema) + 
-								Geonet.Path.CONVERT_STYLESHEETS +
-								"/OGCWxSGetCapabilitiesto19119/" + 
-								"/OGC" +
-								params.ogctype.substring(0,3) + 
-								"GetCapabilitiesLayer-to-19139.xsl";
-		Element xml 		= null;
-		
-		boolean exist;
-		boolean loaded 		= false;
-		
-		if (params.ogctype.substring(0,3).equals("WMS")) {
-			Element name;
-			if (params.ogctype.substring(3,8).equals("1.3.0")) {
-				Namespace wms = Namespace.getNamespace("http://www.opengis.net/wms");
-				name = layer.getChild ("Name", wms);
-			} else {
-				name = layer.getChild ("Name");
-			}
-			//--- For the moment, skip non-requestable category layers
-			if (name == null || name.getValue().trim().equals("")) {
-				log.info("  - skipping layer with no name element");
-				return null;
-			}
-			reg.name = name.getValue();
-		} else if (params.ogctype.substring(0,3).equals("WFS")) {
-			Namespace wfs = Namespace.getNamespace("http://www.opengis.net/wfs");
-			reg.name 	= layer.getChild ("Name", wfs).getValue ();
-		} else if (params.ogctype.substring(0,3).equals("WCS")) {
-			Namespace wcs = Namespace.getNamespace("http://www.opengis.net/wcs");
-			reg.name 	= layer.getChild ("name", wcs).getValue ();
-		} else if (params.ogctype.substring(0,3).equals("SOS")) {
-			Namespace gml = Namespace.getNamespace("http://www.opengis.net/gml");
-			reg.name 	= layer.getChild ("name", gml).getValue ();
-		}
-		
-		log.info ("  - Loading layer: " + reg.name);
-		
-		//--- md5 the full capabilities URL + the layer, coverage or feature name
-		reg.uuid = Sha1Encoder.encodeString(this.capabilitiesUrl+"#"+reg.name); // the dataset identifier
-	
-		//--- Trying loading metadataUrl element
-		if (params.useLayerMd && ! params.ogctype.substring(0,3).equals("WMS") && ! params.ogctype.substring(0,3).equals("WFS")) {
-			log.info("  - MetadataUrl harvester only supported for WMS or WFS layers.");
-		}
-		
-		if (params.useLayerMd && (params.ogctype.substring(0,3).equals("WMS")
-				|| params.ogctype.substring(0,3).equals("WFS"))) {
-			
-			Namespace xlink 	= Namespace.getNamespace ("http://www.w3.org/1999/xlink");
-			
-			// Get metadataUrl xlink:href
-			// TODO : add support for WCS & WFS metadataUrl element.
+    private WxSLayerRegistry addLayerMetadata(Element layer, Element capa) throws JDOMException {
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        Date dt = new Date();
+        WxSLayerRegistry reg = new WxSLayerRegistry();
+        String schema;
+        String mdXml;
+        String date = df.format(dt);
+        // --- Loading stylesheet
+        String styleSheet = schemaMan.getSchemaDir(params.outputSchema) + Geonet.Path.CONVERT_STYLESHEETS
+                + "/OGCWxSGetCapabilitiesto19119/" + "/OGC" + params.ogctype.substring(0, 3)
+                + "GetCapabilitiesLayer-to-19139.xsl";
+        Element xml = null;
 
+        boolean exist;
+        boolean loaded = false;
 
-            // Check if add namespace prefix to Xpath queries.  If layer.getNamespace() is:
-            //    * Namespace.NO_NAMESPACE, should not be added, otherwise exception is launched
-            //    * Another namespace, should be added a namespace prefix to Xpath queries, otherwise doesn't find any result
+        if (params.ogctype.substring(0, 3).equals("WMS")) {
+            Element name;
+            if (params.ogctype.substring(3, 8).equals("1.3.0")) {
+                Namespace wms = Namespace.getNamespace("http://www.opengis.net/wms");
+                name = layer.getChild("Name", wms);
+            } else {
+                name = layer.getChild("Name");
+            }
+            // --- For the moment, skip non-requestable category layers
+            if (name == null || name.getValue().trim().equals("")) {
+                log.info("  - skipping layer with no name element");
+                return null;
+            }
+            reg.name = name.getValue();
+        } else if (params.ogctype.substring(0, 3).equals("WFS")) {
+            Namespace wfs = Namespace.getNamespace("http://www.opengis.net/wfs");
+            reg.name = layer.getChild("Name", wfs).getValue();
+        } else if (params.ogctype.substring(0, 3).equals("WCS")) {
+            Namespace wcs = Namespace.getNamespace("http://www.opengis.net/wcs");
+            reg.name = layer.getChild("name", wcs).getValue();
+        } else if (params.ogctype.substring(0, 3).equals("SOS")) {
+            Namespace gml = Namespace.getNamespace("http://www.opengis.net/gml");
+            reg.name = layer.getChild("name", gml).getValue();
+        }
+
+        log.info("  - Loading layer: " + reg.name);
+
+        // --- md5 the full capabilities URL + the layer, coverage or feature
+        // name
+        reg.uuid = Sha1Encoder.encodeString(this.capabilitiesUrl + "#" + reg.name); // the
+                                                                                    // dataset
+                                                                                    // identifier
+
+        // --- Trying loading metadataUrl element
+        if (params.useLayerMd && !params.ogctype.substring(0, 3).equals("WMS")
+                && !params.ogctype.substring(0, 3).equals("WFS")) {
+            log.info("  - MetadataUrl harvester only supported for WMS or WFS layers.");
+        }
+
+        if (params.useLayerMd
+                && (params.ogctype.substring(0, 3).equals("WMS") || params.ogctype.substring(0, 3).equals("WFS"))) {
+
+            Namespace xlink = Namespace.getNamespace("http://www.w3.org/1999/xlink");
+
+            // Get metadataUrl xlink:href
+            // TODO : add support for WCS & WFS metadataUrl element.
+
+            // Check if add namespace prefix to Xpath queries. If
+            // layer.getNamespace() is:
+            // * Namespace.NO_NAMESPACE, should not be added, otherwise
+            // exception is launched
+            // * Another namespace, should be added a namespace prefix to Xpath
+            // queries, otherwise doesn't find any result
             String dummyNsPrefix = "";
             boolean addNsPrefix = !layer.getNamespace().equals(Namespace.NO_NAMESPACE);
-            if (addNsPrefix) dummyNsPrefix = "x:";
+            if (addNsPrefix)
+                dummyNsPrefix = "x:";
 
             // WMS
-			if (params.ogctype.substring(0, 3).equals("WMS")) {
+            if (params.ogctype.substring(0, 3).equals("WMS")) {
 
-				XPath mdUrl = XPath.newInstance("./" + dummyNsPrefix
-						+ "MetadataURL[@type='TC211' and " + dummyNsPrefix
-						+ "Format='text/xml']/" + dummyNsPrefix
-						+ "OnlineResource");
-				if (addNsPrefix)
-					mdUrl.addNamespace("x", layer.getNamespace().getURI());
-				Element onLineSrc = (Element) mdUrl.selectSingleNode(layer);
+                XPath mdUrl = XPath.newInstance("./" + dummyNsPrefix + "MetadataURL[@type='TC211' and " + dummyNsPrefix
+                        + "Format='text/xml']/" + dummyNsPrefix + "OnlineResource");
+                if (addNsPrefix)
+                    mdUrl.addNamespace("x", layer.getNamespace().getURI());
+                Element onLineSrc = (Element) mdUrl.selectSingleNode(layer);
 
-				// Check if metadataUrl in WMS 1.3.0 format
-				if (onLineSrc == null) {
-					mdUrl = XPath.newInstance("./" + dummyNsPrefix
-							+ "MetadataURL[@type='ISO19115:2003' and "
-							+ dummyNsPrefix + "Format='text/xml']/"
-							+ dummyNsPrefix + "OnlineResource");
-					if (addNsPrefix)
-						mdUrl.addNamespace("x", layer.getNamespace().getURI());
-					onLineSrc = (Element) mdUrl.selectSingleNode(layer);
-				}
+                // Check if metadataUrl in WMS 1.3.0 format
+                if (onLineSrc == null) {
+                    mdUrl = XPath.newInstance("./" + dummyNsPrefix + "MetadataURL[@type='ISO19115:2003' and "
+                            + dummyNsPrefix + "Format='text/xml']/" + dummyNsPrefix + "OnlineResource");
+                    if (addNsPrefix)
+                        mdUrl.addNamespace("x", layer.getNamespace().getURI());
+                    onLineSrc = (Element) mdUrl.selectSingleNode(layer);
+                }
 
-				if (onLineSrc != null) {
-					org.jdom.Attribute href = onLineSrc.getAttribute("href",
-							xlink);
+                if (onLineSrc != null) {
+                    org.jdom.Attribute href = onLineSrc.getAttribute("href", xlink);
 
-					if (href != null) { // No metadataUrl attribute for that
-										// layer
-						mdXml = href.getValue();
-						try {
-							xml = Xml.loadFile(new URL(mdXml));
+                    if (href != null) { // No metadataUrl attribute for that
+                                        // layer
+                        mdXml = href.getValue();
+                        try {
+                            xml = Xml.loadFile(new URL(mdXml));
 
-							// If url is CSW GetRecordById remove envelope
-							if (xml.getName().equals("GetRecordByIdResponse")) {
-								xml = (Element) xml.getChildren().get(0);
-							}
+                            // If url is CSW GetRecordById remove envelope
+                            if (xml.getName().equals("GetRecordByIdResponse")) {
+                                xml = (Element) xml.getChildren().get(0);
+                            }
 
-							schema = dataMan.autodetectSchema(xml, null); // ie. iso19115 or 139 or DC
-							// Extract uuid from loaded xml document
-							// FIXME : uuid could be duplicate if metadata
-							// already exist in catalog
-							reg.uuid = dataMan.extractUUID(schema, xml);
-							exist = dataMan.existsMetadataUuid(dbms, reg.uuid);
+                            schema = dataMan.autodetectSchema(xml, null); // ie.
+                                                                          // iso19115
+                                                                          // or
+                                                                          // 139
+                                                                          // or
+                                                                          // DC
+                            // Extract uuid from loaded xml document
+                            // FIXME : uuid could be duplicate if metadata
+                            // already exist in catalog
+                            reg.uuid = dataMan.extractUUID(schema, xml);
+                            exist = dataMan.existsMetadataUuid(dbms, reg.uuid);
 
-							if (exist) {
-								log.warning("    Metadata uuid already exist in the catalogue. Metadata will not be loaded.");
-								result.layerUuidExist++;
-								// Return the layer info even if it exists in
-								// order
-								// to link to the service record.
-								return reg;
-							}
+                            if (exist) {
+                                log.warning("    Metadata uuid already exist in the catalogue. Metadata will not be loaded.");
+                                result.layerUuidExist++;
+                                // Return the layer info even if it exists in
+                                // order
+                                // to link to the service record.
+                                return reg;
+                            }
 
-							if (schema == null) {
-								log.warning("    Failed to detect schema from metadataUrl file. Use GetCapabilities document instead for that layer.");
-								result.unknownSchema++;
-								loaded = false;
-							} else {
-								log.info("  - Load layer metadataUrl document ok: "
-										+ mdXml);
+                            if (schema == null) {
+                                log.warning("    Failed to detect schema from metadataUrl file. Use GetCapabilities document instead for that layer.");
+                                result.unknownSchema++;
+                                loaded = false;
+                            } else {
+                                log.info("  - Load layer metadataUrl document ok: " + mdXml);
 
-								loaded = true;
-								result.layerUsingMdUrl++;
-							}
-							// TODO : catch other exception
-						} catch (Exception e) {
-							log.warning("  - Failed to load layer using metadataUrl attribute : "
-									+ e.getMessage());
-							loaded = false;
-						}
-					} else {
-						log.info("  - No metadataUrl attribute with format text/xml found for that layer");
-						loaded = false;
-					}
-				} else {
-					log.info("  - No OnlineResource found for that layer");
-					loaded = false;
-				}
-			} 
-			// WFS: there are no metadataUrl in WFS 1.0.0, we need to be
-			// in 1.1.0 specifically.
-			else if (params.ogctype.substring(0, 3).equals("WFS")
-					&& params.ogctype.substring(3,8).equals("1.1.0")) {
-				try {
-					xml = getWfsMdFromMetadataUrl(layer);
-					loaded = true;
-				} catch (Throwable e) {
-					log.error("  - Error trying to get the Metadata from the metadataUrl element (WFS): " + e.getMessage());
-					loaded = false;
-				}
-			}
-		}
-		
-		//--- using GetCapabilities document
-		if (!loaded){
-			try {
-				//--- set XSL param to filter on layer and set uuid
-				Map<String, String> param = new HashMap<String, String>();
-				param.put("uuid", reg.uuid);
-				param.put("Name", reg.name);
-				param.put("lang", params.lang);
-				param.put("topic", params.topic);
-				xml = Xml.transform (capa, styleSheet, param);
-                if(log.isDebugEnabled()) log.debug("  - Layer loaded using GetCapabilities document.");
-				
-			} catch (Exception e) {
-				log.warning("  - Failed to do XSLT transformation on Layer element : " + e.getMessage());
-			}
-		}
-		
-		
-		// Insert in db
-		try {
+                                loaded = true;
+                                result.layerUsingMdUrl++;
+                            }
+                            // TODO : catch other exception
+                        } catch (Exception e) {
+                            log.warning("  - Failed to load layer using metadataUrl attribute : " + e.getMessage());
+                            loaded = false;
+                        }
+                    } else {
+                        log.info("  - No metadataUrl attribute with format text/xml found for that layer");
+                        loaded = false;
+                    }
+                } else {
+                    log.info("  - No OnlineResource found for that layer");
+                    loaded = false;
+                }
+            }
+            // WFS: there are no metadataUrl in WFS 1.0.0, we need to be
+            // in 1.1.0 specifically.
+            else if (params.ogctype.substring(0, 3).equals("WFS") && params.ogctype.substring(3, 8).equals("1.1.0")) {
+                try {
+                    xml = getWfsMdFromMetadataUrl(layer);
+                    loaded = true;
+                } catch (Throwable e) {
+                    log.error("  - Error trying to get the Metadata from the metadataUrl element (WFS): "
+                            + e.getMessage());
+                    loaded = false;
+                }
+            }
+        }
+
+        // --- using GetCapabilities document
+        if (!loaded) {
+            try {
+                // --- set XSL param to filter on layer and set uuid
+                Map<String, String> param = new HashMap<String, String>();
+                param.put("uuid", reg.uuid);
+                param.put("Name", reg.name);
+                param.put("lang", params.lang);
+                param.put("topic", params.topic);
+                xml = Xml.transform(capa, styleSheet, param);
+                if (log.isDebugEnabled())
+                    log.debug("  - Layer loaded using GetCapabilities document.");
+
+            } catch (Exception e) {
+                log.warning("  - Failed to do XSLT transformation on Layer element : " + e.getMessage());
+            }
+        }
+
+        // Insert in db
+        try {
 
             //
-            //  insert metadata
+            // insert metadata
             //
             String group = null, isTemplate = null, docType = null, title = null, category = null;
             boolean ufo = false, indexImmediate = false;
-            
-			schema = dataMan.autodetectSchema (xml);
-			
-            reg.id = dataMan.insertMetadata(context, dbms, schema, xml, context.getSerialFactory().getSerial(dbms, "Metadata"), reg.uuid, Integer.parseInt(params.ownerId), group, params.uuid,
-                         isTemplate, docType, title, category, date, date, ufo, indexImmediate);
-			
-			xml = dataMan.updateFixedInfo(schema, reg.id, params.uuid, xml, null, DataManager.UpdateDatestamp.no, dbms, context);
-			
-			int iId = Integer.parseInt(reg.id);
-            if(log.isDebugEnabled()) log.debug("    - Layer loaded in DB.");
 
-            if(log.isDebugEnabled()) log.debug("    - Set Privileges and category.");
+            schema = dataMan.autodetectSchema(xml);
+
+            reg.id = dataMan.insertMetadata(context, dbms, schema, xml,
+                    context.getSerialFactory().getSerial(dbms, "Metadata"), reg.uuid, Integer.parseInt(params.ownerId),
+                    group, params.uuid, isTemplate, docType, title, category, date, date, ufo, indexImmediate);
+
+            xml = dataMan.updateFixedInfo(schema, reg.id, params.uuid, xml, null, DataManager.UpdateDatestamp.no, dbms,
+                    context);
+
+            int iId = Integer.parseInt(reg.id);
+            if (log.isDebugEnabled())
+                log.debug("    - Layer loaded in DB.");
+
+            if (log.isDebugEnabled())
+                log.debug("    - Set Privileges and category.");
             addPrivileges(reg.id, params.getPrivileges(), localGroups, dataMan, context, dbms, log);
 
-            if (params.datasetCategory!=null && !params.datasetCategory.equals(""))
-				dataMan.setCategory (context, dbms, reg.id, params.datasetCategory);
+            if (params.datasetCategory != null && !params.datasetCategory.equals(""))
+                dataMan.setCategory(context, dbms, reg.id, params.datasetCategory);
 
-            if(log.isDebugEnabled()) log.debug("    - Set Harvested.");
-			dataMan.setHarvestedExt(dbms, iId, params.uuid, params.url); // FIXME : harvestUuid should be a MD5 string
-			
-			dbms.commit();
-			
-			dataMan.indexMetadata(dbms, reg.id);
-			
-			try {
-    			// Load bbox info for later use (eg. WMS thumbnails creation)
-    			Namespace gmd 	= Namespace.getNamespace("http://www.isotc211.org/2005/gmd");
-    			Namespace gco 	= Namespace.getNamespace("http://www.isotc211.org/2005/gco");
-    			
-    			ElementFilter bboxFinder = new ElementFilter("EX_GeographicBoundingBox", gmd);
+            if (log.isDebugEnabled())
+                log.debug("    - Set Harvested.");
+            dataMan.setHarvestedExt(dbms, iId, params.uuid, params.url); // FIXME
+                                                                         // :
+                                                                         // harvestUuid
+                                                                         // should
+                                                                         // be a
+                                                                         // MD5
+                                                                         // string
+
+            dbms.commit();
+
+            dataMan.indexMetadata(dbms, reg.id);
+
+            try {
+                // Load bbox info for later use (eg. WMS thumbnails creation)
+                Namespace gmd = Namespace.getNamespace("http://www.isotc211.org/2005/gmd");
+                Namespace gco = Namespace.getNamespace("http://www.isotc211.org/2005/gco");
+
+                ElementFilter bboxFinder = new ElementFilter("EX_GeographicBoundingBox", gmd);
                 @SuppressWarnings("unchecked")
                 Iterator<Element> bboxes = xml.getDescendants(bboxFinder);
-    			
-    			while (bboxes.hasNext()) {
-    				Element box = bboxes.next();
-    				// FIXME : Could be null. Default bbox if from root layer
-    				reg.minx = Double.valueOf(box.getChild("westBoundLongitude", gmd).getChild("Decimal", gco).getText());
-    				reg.miny = Double.valueOf(box.getChild("southBoundLatitude", gmd).getChild("Decimal", gco).getText());
-    				reg.maxx = Double.valueOf(box.getChild("eastBoundLongitude", gmd).getChild("Decimal", gco).getText());
-    				reg.maxy = Double.valueOf(box.getChild("northBoundLatitude", gmd).getChild("Decimal", gco).getText());
-    				
-    			}
-			}  catch (Exception e) {
-	            log.warning("  - Failed to extract layer bbox from metadata : " + e.getMessage());
-	        }
 
-			result.layer ++;
-			log.info("  - metadata loaded with uuid: " + reg.uuid + "/internal id: " + reg.id);
-				
-		} catch (Exception e) {
-			log.warning("  - Failed to load layer metadata : " + e.getMessage());
-			result.unretrievable ++;
-			return null;
-		}
-		
-		return reg;
-	}
-	
+                while (bboxes.hasNext()) {
+                    Element box = bboxes.next();
+                    // FIXME : Could be null. Default bbox if from root layer
+                    reg.minx = Double.valueOf(box.getChild("westBoundLongitude", gmd).getChild("Decimal", gco)
+                            .getText());
+                    reg.miny = Double.valueOf(box.getChild("southBoundLatitude", gmd).getChild("Decimal", gco)
+                            .getText());
+                    reg.maxx = Double.valueOf(box.getChild("eastBoundLongitude", gmd).getChild("Decimal", gco)
+                            .getText());
+                    reg.maxy = Double.valueOf(box.getChild("northBoundLatitude", gmd).getChild("Decimal", gco)
+                            .getText());
 
-	/**
-	 * 
-	 * @param layer
-	 * @return
-	 */
-	private Element getWfsMdFromMetadataUrl(Element layer) throws Exception {
+                }
+            } catch (Exception e) {
+                log.warning("  - Failed to extract layer bbox from metadata : " + e.getMessage());
+            }
+
+            result.layer++;
+            log.info("  - metadata loaded with uuid: " + reg.uuid + "/internal id: " + reg.id);
+
+        } catch (Exception e) {
+            log.warning("  - Failed to load layer metadata : " + e.getMessage());
+            result.unretrievable++;
+            return null;
+        }
+
+        return reg;
+    }
+
+    /**
+     * 
+     * @param layer
+     * @return
+     */
+    private Element getWfsMdFromMetadataUrl(Element layer) throws Exception {
         String dummyNsPrefix = "";
 
-        if (! layer.getNamespace().equals(Namespace.NO_NAMESPACE)) {
-        	dummyNsPrefix = "x:";
+        if (!layer.getNamespace().equals(Namespace.NO_NAMESPACE)) {
+            dummyNsPrefix = "x:";
         }
-		XPath mdUrl = XPath.newInstance(String.format("./%sMetadataURL[@type='TC211' and @format='text/xml']/text()",
-				dummyNsPrefix));
+        XPath mdUrl = XPath.newInstance(String.format("./%sMetadataURL[@type='TC211' and @format='text/xml']/text()",
+                dummyNsPrefix));
 
-		if (! layer.getNamespace().equals(Namespace.NO_NAMESPACE)) {
-			mdUrl.addNamespace("x", layer.getNamespace().getURI());
-		}
+        if (!layer.getNamespace().equals(Namespace.NO_NAMESPACE)) {
+            mdUrl.addNamespace("x", layer.getNamespace().getURI());
+        }
 
-		Text onLineSrc = (Text) mdUrl.selectSingleNode(layer);
+        Text onLineSrc = (Text) mdUrl.selectSingleNode(layer);
 
-		if (onLineSrc == null) {
-			throw new Exception("Online resource not found in the WFS XML fragment. Skipping.");
-		} else {
-			return Xml.loadFile(new URL(onLineSrc.getText()));
-		}
-	}
+        if (onLineSrc == null) {
+            throw new Exception("Online resource not found in the WFS XML fragment. Skipping.");
+        } else {
+            return Xml.loadFile(new URL(onLineSrc.getText()));
+        }
+    }
 
-	/** 
-     * Call GeoNetwork service to load thumbnails and create small and 
-     * big ones. 
-     *  
-     *  
-     * @param layer   layer for which the thumbnail needs to be generated
-     *                   
+    /**
+     * Call GeoNetwork service to load thumbnails and create small and big ones.
+     * 
+     * 
+     * @param layer
+     *            layer for which the thumbnail needs to be generated
+     * 
      */
-	private void loadThumbnail (WxSLayerRegistry layer){
-        if(log.isDebugEnabled())
+    private void loadThumbnail(WxSLayerRegistry layer) {
+        if (log.isDebugEnabled())
             log.debug("  - Creating thumbnail for layer metadata: " + layer.name + " id: " + layer.id);
-		Set s = new org.fao.geonet.services.thumbnail.Set ();
-		
-		try {
-			String filename = getMapThumbnail(layer);
-			
-			if (filename != null) {
-                if(log.isDebugEnabled()) log.debug("  - File: " + filename);
-				
-				Element par = new Element ("request");
-				par.addContent(new Element ("id").setText(layer.id));
-				par.addContent(new Element ("version").setText("10"));
-				par.addContent(new Element ("type").setText("large"));
-				
-				Element fname = new Element ("fname").setText(filename);
-				fname.setAttribute("content-type", "image/png");
-				fname.setAttribute("type", "file");
-				fname.setAttribute("size", "");
-				
-				par.addContent(fname);
-				par.addContent(new Element ("add").setText("Add"));
-				par.addContent(new Element ("createSmall").setText("on"));
-				par.addContent(new Element ("smallScalingFactor").setText("180"));
-				par.addContent(new Element ("smallScalingDir").setText("width"));
-				
-				// Call the services 
-				s.execOnHarvest(par, context, dbms, dataMan);
-				dbms.commit();
-				result.thumbnails ++;
-			} else
-				result.thumbnailsFailed ++;
-		} catch (Exception e) {
-			log.warning("  - Failed to set thumbnail for metadata: " + e.getMessage());
-			e.printStackTrace();
-			result.thumbnailsFailed ++;
-		}
-		
-	}
-	
-	/** 
-     * Remove thumbnails directory for all metadata
-     * FIXME : Do this only for existing one !
-     *  
-     * @param id   layer for which the thumbnail needs to be generated
-     *                   
-     */
-	private void unsetThumbnail (String id){
-        if(log.isDebugEnabled()) log.debug("  - Removing thumbnail for layer metadata: " + id);
+        Set s = new org.fao.geonet.services.thumbnail.Set();
 
-		try {
-			String file = Lib.resource.getDir(context, Params.Access.PUBLIC, id);
-			FileCopyMgr.removeDirectoryOrFile(new File(file));
-		} catch (Exception e) {
-			log.warning("  - Failed to remove thumbnail for metadata: " + id + ", error: " + e.getMessage());
-		}
-	}
+        try {
+            String filename = getMapThumbnail(layer);
 
-	
-	
-	/** 
-     * Load thumbnails making a GetMap operation.
-     * Width is 300px. Ratio is computed for height using LatLongBoundingBoxElement.
-     *  
-     *  
-     * @param layer   layer for which the thumbnail needs to be generated
-     *                   
+            if (filename != null) {
+                if (log.isDebugEnabled())
+                    log.debug("  - File: " + filename);
+
+                Element par = new Element("request");
+                par.addContent(new Element("id").setText(layer.id));
+                par.addContent(new Element("version").setText("10"));
+                par.addContent(new Element("type").setText("large"));
+
+                Element fname = new Element("fname").setText(filename);
+                fname.setAttribute("content-type", "image/png");
+                fname.setAttribute("type", "file");
+                fname.setAttribute("size", "");
+
+                par.addContent(fname);
+                par.addContent(new Element("add").setText("Add"));
+                par.addContent(new Element("createSmall").setText("on"));
+                par.addContent(new Element("smallScalingFactor").setText("180"));
+                par.addContent(new Element("smallScalingDir").setText("width"));
+
+                // Call the services
+                s.execOnHarvest(par, context, dbms, dataMan);
+                dbms.commit();
+                result.thumbnails++;
+            } else
+                result.thumbnailsFailed++;
+        } catch (Exception e) {
+            log.warning("  - Failed to set thumbnail for metadata: " + e.getMessage());
+            e.printStackTrace();
+            result.thumbnailsFailed++;
+        }
+
+    }
+
+    /**
+     * Remove thumbnails directory for all metadata FIXME : Do this only for
+     * existing one !
+     * 
+     * @param id
+     *            layer for which the thumbnail needs to be generated
+     * 
      */
-	private String getMapThumbnail (WxSLayerRegistry layer) {
-		String filename = layer.uuid + ".png";
-		String dir = context.getUploadDir();
-		Double r = WIDTH / 
-						(layer.maxx - layer.minx) * 
-						(layer.maxy - layer.miny);
-		
-		
+    private void unsetThumbnail(String id) {
+        if (log.isDebugEnabled())
+            log.debug("  - Removing thumbnail for layer metadata: " + id);
+
+        try {
+            String file = Lib.resource.getDir(context, Params.Access.PUBLIC, id);
+            FileCopyMgr.removeDirectoryOrFile(new File(file));
+        } catch (Exception e) {
+            log.warning("  - Failed to remove thumbnail for metadata: " + id + ", error: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Load thumbnails making a GetMap operation. Width is 300px. Ratio is
+     * computed for height using LatLongBoundingBoxElement.
+     * 
+     * 
+     * @param layer
+     *            layer for which the thumbnail needs to be generated
+     * 
+     */
+    private String getMapThumbnail(WxSLayerRegistry layer) {
+        String filename = layer.uuid + ".png";
+        String dir = context.getUploadDir();
+        Double r = WIDTH / (layer.maxx - layer.minx) * (layer.maxy - layer.miny);
+
         // Usual GetMap url tested with mapserver and geoserver
-		// http://localhost:8080/geoserver/wms?service=WMS&request=GetMap&VERSION=1.1.1&
-		// 		LAYERS=gn:world&WIDTH=200&HEIGHT=200&FORMAT=image/png&BBOX=-180,-90,180,90&STYLES=
-		String url = 
-        		getBaseUrl(params.url) +
-        		"&SERVICE=" + params.ogctype.substring(0,3) +
-        		"&VERSION=" + params.ogctype.substring(3) +
-        		"&REQUEST=" + GETMAP + 
-        		"&FORMAT=" + IMAGE_FORMAT + 
-        		"&WIDTH=" + WIDTH +
-        		"&SRS=EPSG:4326" + 
-        		"&HEIGHT=" + r.intValue() +
-        		"&LAYERS=" + layer.name + 
-        		"&STYLES=" +
-        		"&BBOX=" + 
-        			layer.minx + "," +
-        			layer.miny + "," +
-        			layer.maxx + "," +
-        			layer.maxy
-        		;
-		// All is in Lat/Long epsg:4326
-		
-		HttpClient httpclient = new HttpClient ();
-        GetMethod req = new GetMethod (url);
+        // http://localhost:8080/geoserver/wms?service=WMS&request=GetMap&VERSION=1.1.1&
+        // LAYERS=gn:world&WIDTH=200&HEIGHT=200&FORMAT=image/png&BBOX=-180,-90,180,90&STYLES=
+        String url = getBaseUrl(params.url) + "&SERVICE=" + params.ogctype.substring(0, 3) + "&VERSION="
+                + params.ogctype.substring(3) + "&REQUEST=" + GETMAP + "&FORMAT=" + IMAGE_FORMAT + "&WIDTH=" + WIDTH
+                + "&SRS=EPSG:4326" + "&HEIGHT=" + r.intValue() + "&LAYERS=" + layer.name + "&STYLES=" + "&BBOX="
+                + layer.minx + "," + layer.miny + "," + layer.maxx + "," + layer.maxy;
+        // All is in Lat/Long epsg:4326
 
-        if(log.isDebugEnabled()) log.debug ("Retrieving remote document: " + url);
+        HttpClient httpclient = new HttpClient();
+        GetMethod req = new GetMethod(url);
 
-		// set proxy from settings manager
-		Lib.net.setupProxy(context, httpclient);
-		
-		try {
-		    // Connect
-			int result = httpclient.executeMethod (req);
-            if(log.isDebugEnabled()) log.debug("   Get " + result);
+        if (log.isDebugEnabled())
+            log.debug("Retrieving remote document: " + url);
 
-			if (result == 200) {
-			    // Save image document to temp directory
-				// TODO: Check OGC exception
+        // set proxy from settings manager
+        Lib.net.setupProxy(context, httpclient);
+
+        try {
+            // Connect
+            int result = httpclient.executeMethod(req);
+            if (log.isDebugEnabled())
+                log.debug("   Get " + result);
+
+            if (result == 200) {
+                // Save image document to temp directory
+                // TODO: Check OGC exception
                 OutputStream fo = null;
                 InputStream in = null;
-                
+
                 try {
-                    fo = new FileOutputStream (dir + filename);
+                    fo = new FileOutputStream(dir + filename);
                     in = req.getResponseBodyAsStream();
-                    BinaryFile.copy (in,fo);
+                    BinaryFile.copy(in, fo);
                 } finally {
                     IOUtils.closeQuietly(in);
                     IOUtils.closeQuietly(fo);
                 }
-			} else {
-				log.info (" Http error connecting");
-				return null;
-			}
-		} catch (HttpException he) {
-			log.info (" Http error connecting to '" + httpclient.toString() + "'");
-			log.info (he.getMessage());
-			return null;
-		} catch (IOException ioe){
-			log.info (" Unable to connect to '" + httpclient.toString() + "'");
-			log.info (ioe.getMessage());
-			return null;
-		} finally {
-		    // Release current connection to the connection pool once you are done
-		    req.releaseConnection ();
-		}
-		
-		return filename;
-	}
+            } else {
+                log.info(" Http error connecting");
+                return null;
+            }
+        } catch (HttpException he) {
+            log.info(" Http error connecting to '" + httpclient.toString() + "'");
+            log.info(he.getMessage());
+            return null;
+        } catch (IOException ioe) {
+            log.info(" Unable to connect to '" + httpclient.toString() + "'");
+            log.info(ioe.getMessage());
+            return null;
+        } finally {
+            // Release current connection to the connection pool once you are
+            // done
+            req.releaseConnection();
+        }
 
-	/** 
-     * Add '?' or '&' if required to url so that parameters can just be 
-     * appended to it 
-     *   
-     * @param url		Url to which parameters are going to be appended
-     * 
-     */
-	private String getBaseUrl(String url) {
-		if (url.endsWith("?")) {
-			return url;
-		} else if (url.contains("?")) {
-			return url+"&";
-		} else {
-			return url+"?";
-		}
-	}
-
-	//---------------------------------------------------------------------------
-	//---
-	//--- Variables
-	//---
-	//---------------------------------------------------------------------------
-
-	private Logger         log;
-	private ServiceContext context;
-	private Dbms           dbms;
-	private OgcWxSParams   params;
-	private DataManager    dataMan;
-	private SchemaManager  schemaMan;
-	private CategoryMapper localCateg;
-	private GroupMapper    localGroups;
-    private HarvestResult   result;
+        return filename;
+    }
 
     /**
-	 * Store the GetCapabilities operation URL. This URL is scrambled
-	 * and used to uniquelly identified the service. The idea of generating
-	 * a uuid based on the URL instead of a randomuuid is to be able later
-	 * to do an update of the service metadata (which could have been updated
-	 * in the catalogue) instead of a delete/insert operation.
-	 */
-	private String capabilitiesUrl;
+     * Add '?' or '&' if required to url so that parameters can just be appended
+     * to it
+     * 
+     * @param url
+     *            Url to which parameters are going to be appended
+     * 
+     */
+    private String getBaseUrl(String url) {
+        if (url.endsWith("?")) {
+            return url;
+        } else if (url.contains("?")) {
+            return url + "&";
+        } else {
+            return url + "?";
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // ---
+    // --- Variables
+    // ---
+    // ---------------------------------------------------------------------------
+
+    private Logger log;
+    private ServiceContext context;
+    private Dbms dbms;
+    private OgcWxSParams params;
+    private DataManager dataMan;
+    private SchemaManager schemaMan;
+    private CategoryMapper localCateg;
+    private GroupMapper localGroups;
+    private HarvestResult result;
+
+    /**
+     * Store the GetCapabilities operation URL. This URL is scrambled and used
+     * to uniquelly identified the service. The idea of generating a uuid based
+     * on the URL instead of a randomuuid is to be able later to do an update of
+     * the service metadata (which could have been updated in the catalogue)
+     * instead of a delete/insert operation.
+     */
+    private String capabilitiesUrl;
     private static final int WIDTH = 900;
-	private static final String GETCAPABILITIES = "GetCapabilities";
-	private static final String GETMAP = "GetMap";
+    private static final String GETCAPABILITIES = "GetCapabilities";
+    private static final String GETMAP = "GetMap";
     private static final String IMAGE_FORMAT = "image/png";
     private List<WxSLayerRegistry> layersRegistry = new ArrayList<WxSLayerRegistry>();
-	
-	private static class WxSLayerRegistry {
-		public String uuid;
-		public String id;
-		public String name;
-		public Double minx = -180.0;
-		public Double miny = -90.0;
-		public Double maxx = 180.0;
-		public Double maxy = 90.0;
-	}
+
+    private static class WxSLayerRegistry {
+        public String uuid;
+        public String id;
+        public String name;
+        public Double minx = -180.0;
+        public Double miny = -90.0;
+        public Double maxx = 180.0;
+        public Double maxy = 90.0;
+    }
 
 }

--- a/web/src/test/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/HarvesterTest.java
+++ b/web/src/test/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/HarvesterTest.java
@@ -1,0 +1,124 @@
+package org.fao.geonet.kernel.harvest.harvester.ogcwxs;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import jeeves.server.context.ServiceContext;
+import jeeves.utils.Xml;
+
+import org.fao.geonet.GeonetContext;
+import org.jdom.Element;
+import org.jdom.filter.Filter;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.util.ReflectionUtils;
+
+
+
+public class HarvesterTest {
+
+	private Element prepareFeatureTypeFragment(URL fixture, String rebasedUrl) throws Exception {
+		Element featureType = Xml.loadFile(fixture);
+		// Adapt the MetadataURL to point to the test resources
+		Filter filter = new Filter() {
+			private static final long serialVersionUID = 3236424199969896193L;
+			@Override
+			public boolean matches(Object obj) {
+				if (obj instanceof Element) {
+					Element elem = (Element) obj;
+					return elem.getName().equals("MetadataURL");
+				}
+				return false;
+			}
+		};
+		// Need 2 passes, because of ConcurrentModificationException
+		List<Element> subList = new ArrayList<Element>();		
+		Iterator<Object> metadataUrlsElem = featureType.getDescendants(filter);
+		while (metadataUrlsElem.hasNext()) {
+			subList.add((Element) metadataUrlsElem.next());
+		}
+		for (Element e: subList) {
+			if (rebasedUrl != null) {
+				e.setText(rebasedUrl);
+			} else
+				// detach the element
+				e.getParentElement().removeContent(e);
+		}
+		return featureType;
+	}
+	
+	@Test
+	public void extractWfs110MdUrlTest() throws Exception {
+		URL fixture = this.getClass().getResource("wfs-featuretype-fragment.xml");
+		assumeNotNull(fixture);
+		URL mdUrl  = this.getClass().getResource("md.xml");
+		assumeNotNull(mdUrl);
+		Element featureType = prepareFeatureTypeFragment(fixture, mdUrl.toString());
+		ServiceContext ctx = Mockito.mock(ServiceContext.class);
+		Mockito.when(ctx.getHandlerContext(Mockito.anyString())).thenReturn(Mockito.mock(GeonetContext.class));
+		Harvester h = new Harvester(null, ctx, null, null);
+		Method m = ReflectionUtils.findMethod(h.getClass(), "getWfsMdFromMetadataUrl", Element.class);
+		m.setAccessible(true);
+		
+		Element xml = (Element) ReflectionUtils.invokeMethod(m, h, featureType);
+
+		String titlePattern = "Activités économiques de Picardie - sites (2012)";
+		assertTrue(String.format(
+				"Expected '%s' as MD title, not found in the remote document",
+				titlePattern), Xml.getString(xml).contains(titlePattern));
+	}
+	
+	@Test
+	public void extractWfs110NoMdUrlTest() throws Exception {
+		URL fixture = this.getClass().getResource("wfs-featuretype-fragment.xml");
+		assumeNotNull(fixture);
+		Element featureType = prepareFeatureTypeFragment(fixture, null);
+		ServiceContext ctx = Mockito.mock(ServiceContext.class);
+		Mockito.when(ctx.getHandlerContext(Mockito.anyString())).thenReturn(Mockito.mock(GeonetContext.class));
+		Harvester h = new Harvester(null, ctx, null, null);
+		Method m = ReflectionUtils.findMethod(h.getClass(), "getWfsMdFromMetadataUrl", Element.class);
+		m.setAccessible(true);
+
+		boolean noMdUrlFoundCaught = false;
+		try {
+			Element xml = (Element) ReflectionUtils.invokeMethod(m, h, featureType);
+		} catch (Throwable e) {
+			Throwable e1 = e.getCause();
+			noMdUrlFoundCaught = e1.getMessage().contains("not found in the WFS XML fragment");
+		}
+		assertTrue("No exception caught, expected one (no MdUrl found)", noMdUrlFoundCaught);
+	}
+	
+	@Test
+	public void extractWfs110MdUrlFileNotFoundTest() throws Exception {
+		URL fixture = this.getClass().getResource("wfs-featuretype-fragment.xml");
+		URL fileNotfound = new URL("file:/this/file/does/not/exist.xml");
+		assumeNotNull(fixture);
+		assumeTrue(! new File(fileNotfound.toURI()).exists());
+
+		Element featureType = prepareFeatureTypeFragment(fixture, fileNotfound.toString());
+		ServiceContext ctx = Mockito.mock(ServiceContext.class);
+		Mockito.when(ctx.getHandlerContext(Mockito.anyString())).thenReturn(Mockito.mock(GeonetContext.class));
+		Harvester h = new Harvester(null, ctx, null, null);
+		Method m = ReflectionUtils.findMethod(h.getClass(), "getWfsMdFromMetadataUrl", Element.class);
+		m.setAccessible(true);
+
+		boolean fileNotFoundExCaught = false;
+		try {
+			Element xml = (Element) ReflectionUtils.invokeMethod(m, h, featureType);
+		} catch (Throwable e) {
+			Throwable e1 = e.getCause();
+			fileNotFoundExCaught = e1 instanceof FileNotFoundException;
+		}
+		assertTrue("No exception caught, expected one (no MdUrl found)", fileNotFoundExCaught);
+	}	
+}

--- a/web/src/test/resources/org/fao/geonet/kernel/harvest/harvester/ogcwxs/md.xml
+++ b/web/src/test/resources/org/fao/geonet/kernel/harvest/harvester/ogcwxs/md.xml
@@ -1,0 +1,16 @@
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:gml="http://www.opengis.net/gml" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd http://www.isotc211.org/2005/srv http://schemas.opengis.net/iso/19139/20060504/srv/srv.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>53ce7e52-4de8-4737-9e66-98b712746ae0</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>Activités économiques de Picardie - sites (2012)</gco:CharacterString>
+          </gmd:title>
+        </gmd:CI_Citation>
+      </gmd:citation>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/web/src/test/resources/org/fao/geonet/kernel/harvest/harvester/ogcwxs/wfs-featuretype-fragment.xml
+++ b/web/src/test/resources/org/fao/geonet/kernel/harvest/harvester/ogcwxs/wfs-featuretype-fragment.xml
@@ -1,0 +1,18 @@
+<FeatureType xmlns="http://www.opengis.net/wfs" xmlns:geopicardie="http://www.geopicardie.fr/geopicardie">
+  <Name>geopicardie:activite_eco_sites</Name>
+  <Title>Activités économiques - sites</Title>
+  <Abstract>Sites de la base activités économiques de GéoPicardie (zones dʼactivités). La base de données "activités économiques" de GéoPicardie contient la localisation des établissements (au sens de la base SIRENE de l'INSEE), les sites (zones dʼactivités économiques) et les pôles (regroupement de sites). La présente couche contient les sites. La délimitation de ces sites est issue de données remontées par des acteurs locaux de GéoPicardie et complétée par un travail de photo-interprétation.</Abstract>
+  <ows:Keywords xmlns:ows="http://www.opengis.net/ows">
+    <ows:Keyword>activité économique</ows:Keyword>
+    <ows:Keyword>zones d'activités</ows:Keyword>
+    <ows:Keyword>commerces</ows:Keyword>
+    <ows:Keyword>industries</ows:Keyword>
+  </ows:Keywords>
+  <DefaultSRS>urn:x-ogc:def:crs:EPSG:2154</DefaultSRS>
+  <ows:WGS84BoundingBox xmlns:ows="http://www.opengis.net/ows">
+    <ows:LowerCorner>1.2962060620120572 48.85028363134327</ows:LowerCorner>
+    <ows:UpperCorner>4.220573582883188 50.34879744780568</ows:UpperCorner>
+  </ows:WGS84BoundingBox>
+  <MetadataURL type="TC211" format="text/html">http://www.geopicardie.fr/geonetwork/apps/georchestra/?uuid=53ce7e52-4de8-4737-9e66-98b712746ae0</MetadataURL>
+  <MetadataURL type="TC211" format="text/xml">http://www.geopicardie.fr/geonetwork/srv/fre/xml_iso19139?uuid=53ce7e52-4de8-4737-9e66-98b712746ae0</MetadataURL>
+</FeatureType>


### PR DESCRIPTION
This feature is funded by GéoPicardie: The goal of this PR is to address the fetching of WFS MetadataUrl in case they are specified into the `<FeatureType/> WFS GetCapabilities` response, and avoid creating extra metadatas.

This does basically the same thing as what was already done for WMS.

Tests: Added some tests to extract and load remote metadata url ;
Runtime tested, following the scenario below:
- Declare a WFS harvesting endpoint (geopicardie)
- Declare a WMS harvesting endpoint (geopicardie)
- Harvest the WFS
- Harvest the WMS
- Ensure that the WMS does not recreate back the same metadatas
