### PR TITLE
Wxs harvesting do not delete md across harvest

### DIFF
--- a/jeeves/src/main/java/jeeves/utils/XmlRequest.java
+++ b/jeeves/src/main/java/jeeves/utils/XmlRequest.java
@@ -67,6 +67,7 @@ import java.util.List;
 public class XmlRequest
 {
 	public enum Method { GET, POST }
+	private String customUserAgent = null;
 
 	//---------------------------------------------------------------------------
 	//---
@@ -318,6 +319,10 @@ public class XmlRequest
 		client.getParams().setAuthenticationPreemptive(true);
 		serverAuthent = true;
 	}
+	
+	public void setCustomUserAgent(String ua) {
+		this.customUserAgent = ua;
+	}
 
 	//---------------------------------------------------------------------------
 	//---
@@ -336,6 +341,9 @@ public class XmlRequest
 
 		try
 		{
+			if (this.customUserAgent != null) {
+				httpMethod.setRequestHeader("User-Agent", this.customUserAgent);
+			}
 			client.executeMethod(httpMethod);
 			data = httpMethod.getResponseBody();
 

--- a/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/UUIDMapper.java
+++ b/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/UUIDMapper.java
@@ -85,6 +85,12 @@ public class UUIDMapper
 	//--------------------------------------------------------------------------
 
 	public Iterable<String> getUUIDs() { return hmUuidDate.keySet(); }
+	
+	public void removeUuid(String uuid) {
+		hmUuidDate.remove(uuid);
+		hmUuidId.remove(uuid);
+		hmUuidTemplate.remove(uuid);
+	}
 }
 
 //=============================================================================

--- a/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -38,13 +38,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import jeeves.interfaces.Logger;
-import jeeves.resources.dbms.Dbms;
-import jeeves.server.context.ServiceContext;
-import jeeves.utils.BinaryFile;
-import jeeves.utils.Xml;
-import jeeves.utils.XmlRequest;
-
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -69,6 +62,15 @@ import org.jdom.Namespace;
 import org.jdom.Text;
 import org.jdom.filter.ElementFilter;
 import org.jdom.xpath.XPath;
+
+import jeeves.exceptions.BadSoapResponseEx;
+import jeeves.exceptions.BadXmlResponseEx;
+import jeeves.interfaces.Logger;
+import jeeves.resources.dbms.Dbms;
+import jeeves.server.context.ServiceContext;
+import jeeves.utils.BinaryFile;
+import jeeves.utils.Xml;
+import jeeves.utils.XmlRequest;
 
 //=============================================================================
 /**
@@ -140,512 +142,568 @@ import org.jdom.xpath.XPath;
  */
 class Harvester extends BaseAligner {
 
-    /**
-     * Constructor
-     * 
-     * @param log
-     * @param context
-     *            Jeeves context
-     * @param dbms
-     *            Database
-     * @param params
-     *            Information about harvesting configuration for the node
-     * 
-     * @return null
-     */
-    public Harvester(Logger log, ServiceContext context, Dbms dbms, OgcWxSParams params) {
-        this.log = log;
-        this.context = context;
-        this.dbms = dbms;
-        this.params = params;
-
-        result = new HarvestResult();
-
-        GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
-        dataMan = gc.getDataManager();
-        schemaMan = gc.getSchemamanager();
-    }
-
-    // ---------------------------------------------------------------------------
-    // ---
-    // --- API methods
-    // ---
-    // ---------------------------------------------------------------------------
-    /**
-     * Start the harvesting of a WMS, WFS or WCS node.
-     */
-    public HarvestResult harvest() throws Exception {
-        Element xml;
-
-        log.info("Retrieving remote metadata information for : " + params.name);
-
-
-        UUIDMapper localUuids = new UUIDMapper(dbms, params.uuid);
-
-        // Try to load capabilities document
-        this.capabilitiesUrl = getBaseUrl(params.url) + "SERVICE=" + params.ogctype.substring(0, 3) + "&VERSION="
-                + params.ogctype.substring(3) + "&REQUEST=" + GETCAPABILITIES;
-
-        if (log.isDebugEnabled())
-            log.debug("GetCapabilities document: " + this.capabilitiesUrl);
-
-        XmlRequest req = new XmlRequest();
-        req.setUrl(new URL(this.capabilitiesUrl));
-        req.setMethod(XmlRequest.Method.GET);
-        Lib.net.setupProxy(context, req);
-
-        if (params.useAccount) {
-            req.setCredentials(params.username, params.password);
-        }
-
-        xml = req.execute();
-
-        // Convert from GetCapabilities to ISO19119
-        // also adds the children data metadata (if enabled)
-        addMetadata(xml, localUuids);
-
-        // every remaining metadata into localUuids have to be removed
-        log.info("After harvesting, still " + ((java.util.Set<String>) localUuids.getUUIDs()).size() + " to remove");
-        for (String uuid: localUuids.getUUIDs()) {
-        	try {
-        		String mdId = dataMan.getMetadataId(dbms, uuid);
-        		log.info("Deleting MD "+ mdId + " (" + uuid + ")");
-            	dataMan.deleteMetadata(context, dbms, mdId);
-            	result.locallyRemoved++;
-        	} catch (Exception e) {
-        		log.error("MD (" + uuid + ") not found, skipping deletion");
-        	}
-        }
-        dbms.commit();
-
-        result.totalMetadata = result.addedMetadata + result.layer;
-
-        return result;
-    }
-
-    /**
-     * Add metadata to the node for a WxS service
-     * 
-     * 1.Use GetCapabilities Document
-     * 2.Transform using XSLT to iso19119
-     * 3.Loop through layers
-     * 4.Create md for layer
-     * 5.Add operatesOn elem with uuid
-     * 6.Save all
-     *
-     * @param capa
-     *            GetCapabilities document
-     * @param localUuids 
-     * 
-     */
-    private void addMetadata(Element capa, UUIDMapper localUuids) throws Exception {
-        if (capa == null)
-            return;
-
-        // --- Loading categories and groups
-        localCateg = new CategoryMapper(dbms);
-        localGroups = new GroupMapper(dbms);
-
-        // sha1 the full capabilities URL
-        String uuid = Sha1Encoder.encodeString(this.capabilitiesUrl);
-
-        // Removes the previous service metadata
-        dbms.execute("DELETE FROM metadata WHERE uuid = ? AND harvestuuid = ? LIMIT 1", uuid, params.uuid);
-        dbms.commit();
-        localUuids.removeUuid(uuid);
-
-        // --- Loading stylesheet
-        String styleSheet = schemaMan.getSchemaDir(params.outputSchema) + Geonet.Path.CONVERT_STYLESHEETS
-                + "/OGCWxSGetCapabilitiesto19119/" + "/OGC" + params.ogctype.substring(0, 3)
-                + "GetCapabilities-to-ISO19119_ISO19139.xsl";
-
-        if (log.isDebugEnabled())
-            log.debug("  - XSLT transformation using " + styleSheet);
-
-        Map<String, String> param = new HashMap<String, String>();
-        param.put("lang", params.lang);
-        param.put("topic", params.topic);
-        param.put("uuid", uuid);
-
-        Element md = Xml.transform(capa, styleSheet, param);
-
-        String schema = dataMan.autodetectSchema(md, null); // ie. iso19139;
-
-        if (schema == null) {
-            log.warning("Skipping metadata with unknown schema.");
-            result.unknownSchema++;
-        }
-
-        // --- Create metadata for layers only if user ask for
-        if (params.useLayer || params.useLayerMd) {
-            // Load CRS
-            // TODO
-
-            // --- Select layers, featureTypes and Coverages (for layers having
-            // no child named layer = not take group of layer into account)
-            // and add the metadata
-            XPath xp = XPath.newInstance("//Layer[count(./*[name(.)='Layer'])=0] | "
-                    + "//wms:Layer[count(./*[name(.)='Layer'])=0] | " + "//wfs:FeatureType | "
-                    + "//wcs:CoverageOfferingBrief | " + "//sos:ObservationOffering");
-            xp.addNamespace("wfs", "http://www.opengis.net/wfs");
-            xp.addNamespace("wcs", "http://www.opengis.net/wcs");
-            xp.addNamespace("wms", "http://www.opengis.net/wms");
-            xp.addNamespace("sos", "http://www.opengis.net/sos/1.0");
-
-            @SuppressWarnings("unchecked")
-            List<Element> layers = xp.selectNodes(capa);
-            if (layers.size() > 0) {
-                log.info("  - Number of layers, featureTypes or Coverages found : " + layers.size());
-
-                for (Element layer : layers) {
-                    WxSLayerRegistry s = addLayerMetadata(layer, capa);
-                    localUuids.removeUuid(s.uuid);
-                    if (s != null)
-                        layersRegistry.add(s);
-                }
-
-                // Update ISO19119 for data/service links creation (ie.
-                // operatesOn element)
-                // The editor will support that but it will make quite heavy
-                // XML.
-                md = addOperatesOnUuid(md, layersRegistry);
-            }
-        }
-
-        // Save iso19119 (service) metadata in DB
-        log.info("  - Adding metadata for services with " + uuid);
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-        Date date = new Date();
-
-        //
-        // insert metadata
-        //
-        String group = null, isTemplate = null, docType = null, title = null, category = null;
-        boolean ufo = false, indexImmediate = false;
-        String id = dataMan.insertMetadata(context, dbms, schema, md,
-                context.getSerialFactory().getSerial(dbms, "Metadata"), uuid, Integer.parseInt(params.ownerId), group,
-                params.uuid, isTemplate, docType, title, category, df.format(date), df.format(date), ufo,
-                indexImmediate);
-
-        int iId = Integer.parseInt(id);
-
-        addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context, dbms, log);
-        addCategories(id, params.getCategories(), localCateg, dataMan, dbms, context, log, null);
-
-        dataMan.setHarvestedExt(dbms, iId, params.uuid, params.url);
-        dataMan.setTemplate(dbms, iId, "n", null);
-
-        dbms.commit();
-        // dataMan.indexMetadata(dbms, id); setTemplate update the index
-
-        result.addedMetadata++;
-
-        // Add Thumbnails only after metadata insertion to avoid concurrent
-        // transaction  and loaded thumbnails could eventually fail anyway.
-        if (params.ogctype.startsWith("WMS") && params.createThumbnails) {
-            for (WxSLayerRegistry layer : layersRegistry) {
-                loadThumbnail(layer);
-            }
-        }
-    }
-
-    /**
-     * Add OperatesOn elements on an ISO19119 metadata
-     * 
-     * <srv:operatesOn> <gmd:MD_DataIdentification uuidref=""/>
-     * </srv:operatesOn>
-     *
-     * @param md
-     *            iso19119 metadata
-     * @param layersRegistry
-     *            uuid to be added as an uuidref attribute
-     * 
-     */
-    private Element addOperatesOnUuid(Element md, List<WxSLayerRegistry> layersRegistry) {
-
-        Namespace gmd = Namespace.getNamespace("gmd", "http://www.isotc211.org/2005/gmd");
-        Namespace gco = Namespace.getNamespace("gco", "http://www.isotc211.org/2005/gco");
-        Namespace srv = Namespace.getNamespace("srv", "http://www.isotc211.org/2005/srv");
-        Namespace xlink = Namespace.getNamespace("xlink", "http://www.w3.org/1999/xlink");
-
-        Element root = md.getChild("identificationInfo", gmd).getChild("SV_ServiceIdentification", srv);
-
-        if (root != null) {
-            if (log.isDebugEnabled())
-                log.debug("  - add SV_CoupledResource and OperatesOnUuid");
-
-            Element couplingType = root.getChild("couplingType", srv);
-            int coupledResourceIdx = root.indexOf(couplingType);
-
-            for (WxSLayerRegistry layer : layersRegistry) {
-                // Create coupled resources elements to register all layername
-                // in service metadata. This information could be used to add
-                // interactive map button when viewing service metadata.
-                Element coupledResource = new Element("coupledResource", srv);
-                Element scr = new Element("SV_CoupledResource", srv);
-
-                // Create operation according to service type
-                Element operation = new Element("operationName", srv);
-                Element operationValue = new Element("CharacterString", gco);
-
-                if (params.ogctype.startsWith("WMS"))
-                    operationValue.setText("GetMap");
-                else if (params.ogctype.startsWith("WFS"))
-                    operationValue.setText("GetFeature");
-                else if (params.ogctype.startsWith("WCS"))
-                    operationValue.setText("GetCoverage");
-                else if (params.ogctype.startsWith("SOS"))
-                    operationValue.setText("GetObservation");
-                operation.addContent(operationValue);
-
-                // Create identifier (which is the metadata identifier)
-                Element id = new Element("identifier", srv);
-                Element idValue = new Element("CharacterString", gco);
-                idValue.setText(layer.uuid);
-                id.addContent(idValue);
-
-                // Create scoped name element as defined in CSW 2.0.2 ISO profil
-                // specification to link service metadata to a layer in a
-                // service.
-                Element scopedName = new Element("ScopedName", gco);
-                scopedName.setText(layer.name);
-
-                scr.addContent(operation);
-                scr.addContent(id);
-                scr.addContent(scopedName);
-                coupledResource.addContent(scr);
-
-                // Add coupled resource before coupling type element
-                root.addContent(coupledResourceIdx, coupledResource);
-
-                // Add operatesOn element at the end of identification section.
-                Element op = new Element("operatesOn", srv);
-                op.setAttribute("uuidref", layer.uuid);
-
-                String hRefLink = dataMan.getSiteURL(context) + "/xml.metadata.get?uuid=" + layer.uuid;
-                op.setAttribute("href", hRefLink, xlink);
-
-                root.addContent(op);
-
-            }
-        }
-
-        return md;
-    }
-
-    /**
-     * Add metadata for a Layer/FeatureType/Coverage element of a
-     * GetCapabilities document. This function search for a metadataUrl element
-     * (with @type = TC211 and format = text/xml) and try to load the XML
-     * document. If failed, then an XSLT is used for creating metadata from the
-     * Layer/FeatureType/Coverage element. If loaded document contain an
-     * existing uuid, metadata will not be loaded in the catalogue.
-     * 
-     * @param layer
-     *            Layer/FeatureType/Coverage element
-     * @param capa
-     *            GetCapabilities document
-     * 
-     * @return uuid
-     * 
-     */
-    private WxSLayerRegistry addLayerMetadata(Element layer, Element capa) throws JDOMException {
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-        Date dt = new Date();
-        WxSLayerRegistry reg = new WxSLayerRegistry();
-        String schema;
-        String mdXml;
-        String date = df.format(dt);
-        // --- Loading stylesheet
-        String styleSheet = schemaMan.getSchemaDir(params.outputSchema) + Geonet.Path.CONVERT_STYLESHEETS
-                + "/OGCWxSGetCapabilitiesto19119/" + "/OGC" + params.ogctype.substring(0, 3)
-                + "GetCapabilitiesLayer-to-19139.xsl";
-        Element xml = null;
-
-        boolean exist;
-        boolean loaded = false;
-
-        if (params.ogctype.substring(0, 3).equals("WMS")) {
-            Element name;
-            if (params.ogctype.substring(3, 8).equals("1.3.0")) {
-                Namespace wms = Namespace.getNamespace("http://www.opengis.net/wms");
-                name = layer.getChild("Name", wms);
-            } else {
-                name = layer.getChild("Name");
-            }
-            // --- For the moment, skip non-requestable category layers
-            if (name == null || name.getValue().trim().equals("")) {
-                log.info("  - skipping layer with no name element");
-                return null;
-            }
-            reg.name = name.getValue();
-        } else if (params.ogctype.substring(0, 3).equals("WFS")) {
-            Namespace wfs = Namespace.getNamespace("http://www.opengis.net/wfs");
-            reg.name = layer.getChild("Name", wfs).getValue();
-        } else if (params.ogctype.substring(0, 3).equals("WCS")) {
-            Namespace wcs = Namespace.getNamespace("http://www.opengis.net/wcs");
-            reg.name = layer.getChild("name", wcs).getValue();
-        } else if (params.ogctype.substring(0, 3).equals("SOS")) {
-            Namespace gml = Namespace.getNamespace("http://www.opengis.net/gml");
-            reg.name = layer.getChild("name", gml).getValue();
-        }
-
-        log.info("  - Loading layer: " + reg.name);
-
-        // --- sha1 the full capabilities URL + the layer, coverage or feature name
-        reg.uuid = Sha1Encoder.encodeString(this.capabilitiesUrl + "#" + reg.name); // the dataset identifier
-
-
-        boolean wmsOrWfs = params.ogctype.substring(0, 3).equals("WMS") || params.ogctype.substring(0, 3).equals("WFS");
-        
-        if (params.useLayerMd && ! wmsOrWfs) {
-            log.info("  - MetadataUrl harvester only supported for WMS or WFS layers.");
-        }
-        // --- Trying to load metadataUrl element
-        if (params.useLayerMd && wmsOrWfs) {
-
-            Namespace xlink = Namespace.getNamespace("http://www.w3.org/1999/xlink");
-
-            // Get metadataUrl xlink:href
-            // TODO : add support for WCS metadataUrl element.
-
-            // Check if add namespace prefix to Xpath queries. If
-            // layer.getNamespace() is:
-            // * Namespace.NO_NAMESPACE, should not be added, otherwise
-            // exception is launched
-            // * Another namespace, should be added a namespace prefix to Xpath
-            // queries, otherwise doesn't find any result
-            String dummyNsPrefix = "";
-            boolean addNsPrefix = !layer.getNamespace().equals(Namespace.NO_NAMESPACE);
-            if (addNsPrefix)
-                dummyNsPrefix = "x:";
-
-            // WMS
-            if (params.ogctype.substring(0, 3).equals("WMS")) {
-
-                XPath mdUrl = XPath.newInstance("./" + dummyNsPrefix + "MetadataURL[@type='TC211' and " + dummyNsPrefix
-                        + "Format='text/xml']/" + dummyNsPrefix + "OnlineResource");
-                if (addNsPrefix)
-                    mdUrl.addNamespace("x", layer.getNamespace().getURI());
-                Element onLineSrc = (Element) mdUrl.selectSingleNode(layer);
-
-                // Check if metadataUrl in WMS 1.3.0 format
-                if (onLineSrc == null) {
-                    mdUrl = XPath.newInstance("./" + dummyNsPrefix + "MetadataURL[@type='ISO19115:2003' and "
-                            + dummyNsPrefix + "Format='text/xml']/" + dummyNsPrefix + "OnlineResource");
-                    if (addNsPrefix)
-                        mdUrl.addNamespace("x", layer.getNamespace().getURI());
-                    onLineSrc = (Element) mdUrl.selectSingleNode(layer);
-                }
-
-                if (onLineSrc != null) {
-                    org.jdom.Attribute href = onLineSrc.getAttribute("href", xlink);
-                    if (href != null) {
-                        mdXml = href.getValue();
-                        try {
-                            xml = Xml.loadFile(new URL(mdXml));
-
-                            // If url is CSW GetRecordById remove envelope
-                            if (xml.getName().equals("GetRecordByIdResponse")) {
-                                xml = (Element) xml.getChildren().get(0);
-                            }
-
-                            schema = dataMan.autodetectSchema(xml, null); // ie. iso19115 or 139 or DC
-                            // Extract uuid from loaded xml document
-                            reg.uuid = dataMan.extractUUID(schema, xml);
-                            exist = dataMan.existsMetadataUuid(dbms, reg.uuid);
-
-                            if (exist) {
-                                log.warning("    Metadata uuid already exist in the catalogue. Metadata will not be loaded.");
-                                result.layerUuidExist++;
-                                // Return the layer info even if it exists in order
-                                // to link to the service record.
-                                return reg;
-                            }
-
-                            if (schema == null) {
-                                log.warning("    Failed to detect schema from metadataUrl file. Use GetCapabilities document instead for that layer.");
-                                result.unknownSchema++;
-                                loaded = false;
-                            } else {
-                                log.info("  - Load layer metadataUrl document ok: " + mdXml);
-
-                                loaded = true;
-                                result.layerUsingMdUrl++;
-                            }
-                            // TODO : catch other exception
-                        } catch (Exception e) {
-                            log.warning("  - Failed to load layer using metadataUrl attribute : " + e.getMessage());
-                            loaded = false;
-                        }
-                    } else {
-                        log.info("  - No metadataUrl attribute with format text/xml found for that layer");
-                        loaded = false;
-                    }
-                } else {
-                    log.info("  - No OnlineResource found for that layer");
-                    loaded = false;
-                }
-            }
-            // WFS: there are no metadataUrl in WFS 1.0.0, we need to be in 1.1.0 specifically.
-            else if (params.ogctype.substring(0, 3).equals("WFS") && params.ogctype.substring(3, 8).equals("1.1.0")) {
-                try {
-                    xml = getWfsMdFromMetadataUrl(layer);
-                    // applying the same logic as above
-                    if (xml.getName().equals("GetRecordByIdResponse")) {
-                        xml = (Element) xml.getChildren().get(0);
-                    }
-                    schema = dataMan.autodetectSchema(xml, null); // ie. iso19115 or 139 or DC
-                    reg.uuid = dataMan.extractUUID(schema, xml);
-                    exist = dataMan.existsMetadataUuid(dbms, reg.uuid);
-                    if (exist) {
-                        log.warning("    Metadata uuid already exist in the catalogue. Metadata will not be loaded.");
-                        result.layerUuidExist++;
-                        return reg;
-                    }
-                    if (schema == null) {
-                        log.warning("    Failed to detect schema from metadataUrl file. Use GetCapabilities document instead for that layer.");
-                        result.unknownSchema++;
-                        loaded = false;
-                    } else {
-                        loaded = true;
-                        result.layerUsingMdUrl++;
-                    }
-                } catch (Throwable e) {
-                    log.error("  - Error trying to get the Metadata from the metadataUrl element (WFS): " + e.getMessage());
-                    loaded = false;
-                }
-            }
-        }
-        // --- No metadataUrl along with the layer block: using the GetCapabilities document
-        // to generate a new MDD.
-        if (!loaded) {
-            try {
-                // --- set XSL param to filter on layer and set uuid
-                Map<String, String> param = new HashMap<String, String>();
-                param.put("uuid", reg.uuid);
-                param.put("Name", reg.name);
-                param.put("lang", params.lang);
-                param.put("topic", params.topic);
-                xml = Xml.transform(capa, styleSheet, param);
-                if (log.isDebugEnabled())
-                    log.debug("  - Layer loaded using GetCapabilities document.");
-
-            } catch (Exception e) {
-                log.warning("  - Failed to do XSLT transformation on Layer element : " + e.getMessage());
-            }
-        }
-
-        // Insert or update metadata in db
-        try {
-
-            //
-            // insert metadata
-            //
-            exist = dataMan.existsMetadataUuid(dbms, reg.uuid);
+	private static final String GEONETWORK_OGCWXS_UA = "geOrchestra GeoNetwork v2.11 Harvester";
+
+	/**
+	 * Constructor
+	 * 
+	 * @param log
+	 * @param context
+	 *            Jeeves context
+	 * @param dbms
+	 *            Database
+	 * @param params
+	 *            Information about harvesting configuration for the node
+	 * 
+	 * @return null
+	 */
+	public Harvester(Logger log, ServiceContext context, Dbms dbms, OgcWxSParams params) {
+		this.log = log;
+		this.context = context;
+		this.dbms = dbms;
+		this.params = params;
+
+		result = new HarvestResult();
+
+		GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
+		dataMan = gc.getDataManager();
+		schemaMan = gc.getSchemamanager();
+	}
+
+	// ---------------------------------------------------------------------------
+	// ---
+	// --- API methods
+	// ---
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Indicates whether the call to retrieveExternalDocument() should allow
+	 * to retrieve non-http URLs.
+	 * 
+	 * used for testing only (@see HarvesterTest.java)
+	 */
+	private boolean allowLocalRetrieval = false;
+
+	/**
+	 * Fetches a remote (supposedly XML) document
+	 *
+	 * @param url
+	 *            the url where the document is accessible
+	 * @param forceUseAuth
+	 *            indicates whether the configured authentication (http
+	 *            basic-auth), if provided, should be used or not.
+	 *
+	 * @return
+	 * @throws BadXmlResponseEx
+	 * @throws BadSoapResponseEx
+	 * @throws IOException
+	 * @throws JDOMException
+	 */
+	private Element retrieveExternalDocument(String url, boolean forceUseAuth)
+			throws BadXmlResponseEx, BadSoapResponseEx, IOException, JDOMException {
+		URL externalDoc = new URL(url);
+
+		if (!externalDoc.getProtocol().equals("http") && !(externalDoc.getProtocol().equals("https"))) {
+			if (!allowLocalRetrieval) {
+				throw new IllegalArgumentException("Expected http(s) url, got " + url);
+			} else {
+				return Xml.loadFile(new URL(url));
+			}
+		}
+		XmlRequest req = new XmlRequest();
+		req.setUrl(new URL(url));
+		req.setMethod(XmlRequest.Method.GET);
+		req.setCustomUserAgent(GEONETWORK_OGCWXS_UA);
+		Lib.net.setupProxy(context, req);
+		if ((params.useAccount) && (forceUseAuth)) {
+			req.setCredentials(params.username, params.password);
+		}
+		Element xml = req.execute();
+		return xml;
+	}
+
+	/**
+	 * Start the harvesting of a WMS, WFS or WCS node.
+	 */
+	public HarvestResult harvest() throws Exception {
+		Element xml;
+
+		log.info("Retrieving remote metadata information for : " + params.name);
+
+		UUIDMapper localUuids = new UUIDMapper(dbms, params.uuid);
+
+		// Try to load capabilities document
+		this.capabilitiesUrl = getBaseUrl(params.url) + "SERVICE=" + params.ogctype.substring(0, 3) + "&VERSION="
+				+ params.ogctype.substring(3) + "&REQUEST=" + GETCAPABILITIES;
+
+		if (log.isDebugEnabled())
+			log.debug("GetCapabilities document: " + this.capabilitiesUrl);
+
+		xml = retrieveExternalDocument(this.capabilitiesUrl, true);
+
+		// Convert from GetCapabilities to ISO19119
+		// also adds the children data metadata (if enabled)
+		addMetadata(xml, localUuids);
+
+		// every remaining metadata into localUuids have to be removed
+		log.info("After harvesting, still " + ((java.util.Set<String>) localUuids.getUUIDs()).size() + " to remove");
+		for (String uuid : localUuids.getUUIDs()) {
+			try {
+				String mdId = dataMan.getMetadataId(dbms, uuid);
+				log.info("Deleting MD " + mdId + " (" + uuid + ")");
+				dataMan.deleteMetadata(context, dbms, mdId);
+				result.locallyRemoved++;
+			} catch (Exception e) {
+				log.error("MD (" + uuid + ") not found, skipping deletion");
+			}
+		}
+		dbms.commit();
+
+		result.totalMetadata = result.addedMetadata + result.layer;
+
+		return result;
+	}
+
+	/**
+	 * Add metadata to the node for a WxS service
+	 * 
+	 * 1.Use GetCapabilities Document 2.Transform using XSLT to iso19119 3.Loop
+	 * through layers 4.Create md for layer 5.Add operatesOn elem with uuid
+	 * 6.Save all
+	 *
+	 * @param capa
+	 *            GetCapabilities document
+	 * @param localUuids
+	 * 
+	 */
+	private void addMetadata(Element capa, UUIDMapper localUuids) throws Exception {
+		if (capa == null)
+			return;
+
+		// --- Loading categories and groups
+		localCateg = new CategoryMapper(dbms);
+		localGroups = new GroupMapper(dbms);
+
+		// sha1 the full capabilities URL
+		String uuid = Sha1Encoder.encodeString(this.capabilitiesUrl);
+
+		// Removes the previous service metadata (if still existing)
+		String sMdId = dataMan.getMetadataId(dbms, uuid);
+		if (sMdId != null) {
+			dataMan.deleteMetadata(context, dbms, sMdId);
+			dbms.commit();
+		}
+		localUuids.removeUuid(uuid);
+
+		// --- Loading stylesheet
+		String styleSheet = schemaMan.getSchemaDir(params.outputSchema) + Geonet.Path.CONVERT_STYLESHEETS
+				+ "/OGCWxSGetCapabilitiesto19119/" + "/OGC" + params.ogctype.substring(0, 3)
+				+ "GetCapabilities-to-ISO19119_ISO19139.xsl";
+
+		if (log.isDebugEnabled())
+			log.debug("  - XSLT transformation using " + styleSheet);
+
+		Map<String, String> param = new HashMap<String, String>();
+		param.put("lang", params.lang);
+		param.put("topic", params.topic);
+		param.put("uuid", uuid);
+
+		Element md = Xml.transform(capa, styleSheet, param);
+
+		String schema = dataMan.autodetectSchema(md, null); // ie. iso19139;
+
+		if (schema == null) {
+			log.warning("Skipping metadata with unknown schema.");
+			result.unknownSchema++;
+		}
+
+		// --- Create metadata for layers only if user ask for
+		if (params.useLayer || params.useLayerMd) {
+			// Load CRS
+			// TODO
+
+			// --- Select layers, featureTypes and Coverages (for layers having
+			// no child named layer = not take group of layer into account)
+			// and add the metadata
+			XPath xp = XPath.newInstance(
+					"//Layer[count(./*[name(.)='Layer'])=0] | " + "//wms:Layer[count(./*[name(.)='Layer'])=0] | "
+							+ "//wfs:FeatureType | " + "//wcs:CoverageOfferingBrief | " + "//sos:ObservationOffering");
+			xp.addNamespace("wfs", "http://www.opengis.net/wfs");
+			xp.addNamespace("wcs", "http://www.opengis.net/wcs");
+			xp.addNamespace("wms", "http://www.opengis.net/wms");
+			xp.addNamespace("sos", "http://www.opengis.net/sos/1.0");
+
+			@SuppressWarnings("unchecked")
+			List<Element> layers = xp.selectNodes(capa);
+			if (layers.size() > 0) {
+				log.info("  - Number of layers, featureTypes or Coverages found : " + layers.size());
+
+				for (Element layer : layers) {
+					WxSLayerRegistry s = addLayerMetadata(layer, capa);
+					if (s != null) {
+						if (s.uuid != null)
+							localUuids.removeUuid(s.uuid);
+						layersRegistry.add(s);
+					}
+				}
+
+				// Update ISO19119 for data/service links creation (ie.
+				// operatesOn element)
+				// The editor will support that but it will make quite heavy
+				// XML.
+				md = addOperatesOnUuid(md, layersRegistry);
+			}
+		}
+
+		// Save iso19119 (service) metadata in DB
+		log.info("  - Adding metadata for services with " + uuid);
+		DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+		Date date = new Date();
+
+		//
+		// insert metadata
+		//
+		String group = null, isTemplate = null, docType = null, title = null, category = null;
+		boolean ufo = false, indexImmediate = false;
+		String id = dataMan.insertMetadata(context, dbms, schema, md,
+				context.getSerialFactory().getSerial(dbms, "Metadata"), uuid, Integer.parseInt(params.ownerId), group,
+				params.uuid, isTemplate, docType, title, category, df.format(date), df.format(date), ufo,
+				indexImmediate);
+
+		int iId = Integer.parseInt(id);
+
+		addPrivileges(id, params.getPrivileges(), localGroups, dataMan, context, dbms, log);
+		addCategories(id, params.getCategories(), localCateg, dataMan, dbms, context, log, null);
+
+		dataMan.setHarvestedExt(dbms, iId, params.uuid, params.url);
+		dataMan.setTemplate(dbms, iId, "n", null);
+
+		dbms.commit();
+		// dataMan.indexMetadata(dbms, id); setTemplate update the index
+
+		result.addedMetadata++;
+
+		// Add Thumbnails only after metadata insertion to avoid concurrent
+		// transaction and loaded thumbnails could eventually fail anyway.
+		if (params.ogctype.startsWith("WMS") && params.createThumbnails) {
+			for (WxSLayerRegistry layer : layersRegistry) {
+				loadThumbnail(layer);
+			}
+		}
+	}
+
+	/**
+	 * Add OperatesOn elements on an ISO19119 metadata
+	 * 
+	 * <srv:operatesOn> <gmd:MD_DataIdentification uuidref=""/>
+	 * </srv:operatesOn>
+	 *
+	 * @param md
+	 *            iso19119 metadata
+	 * @param layersRegistry
+	 *            uuid to be added as an uuidref attribute
+	 * 
+	 */
+	private Element addOperatesOnUuid(Element md, List<WxSLayerRegistry> layersRegistry) {
+
+		Namespace gmd = Namespace.getNamespace("gmd", "http://www.isotc211.org/2005/gmd");
+		Namespace gco = Namespace.getNamespace("gco", "http://www.isotc211.org/2005/gco");
+		Namespace srv = Namespace.getNamespace("srv", "http://www.isotc211.org/2005/srv");
+		Namespace xlink = Namespace.getNamespace("xlink", "http://www.w3.org/1999/xlink");
+
+		Element root = md.getChild("identificationInfo", gmd).getChild("SV_ServiceIdentification", srv);
+
+		if (root != null) {
+			if (log.isDebugEnabled())
+				log.debug("  - add SV_CoupledResource and OperatesOnUuid");
+
+			Element couplingType = root.getChild("couplingType", srv);
+			int coupledResourceIdx = root.indexOf(couplingType);
+
+			for (WxSLayerRegistry layer : layersRegistry) {
+				// Create coupled resources elements to register all layername
+				// in service metadata. This information could be used to add
+				// interactive map button when viewing service metadata.
+				Element coupledResource = new Element("coupledResource", srv);
+				Element scr = new Element("SV_CoupledResource", srv);
+
+				// Create operation according to service type
+				Element operation = new Element("operationName", srv);
+				Element operationValue = new Element("CharacterString", gco);
+
+				if (params.ogctype.startsWith("WMS"))
+					operationValue.setText("GetMap");
+				else if (params.ogctype.startsWith("WFS"))
+					operationValue.setText("GetFeature");
+				else if (params.ogctype.startsWith("WCS"))
+					operationValue.setText("GetCoverage");
+				else if (params.ogctype.startsWith("SOS"))
+					operationValue.setText("GetObservation");
+				operation.addContent(operationValue);
+
+				// Create identifier (which is the metadata identifier)
+				Element id = new Element("identifier", srv);
+				Element idValue = new Element("CharacterString", gco);
+				idValue.setText(layer.uuid);
+				id.addContent(idValue);
+
+				// Create scoped name element as defined in CSW 2.0.2 ISO profil
+				// specification to link service metadata to a layer in a
+				// service.
+				Element scopedName = new Element("ScopedName", gco);
+				scopedName.setText(layer.name);
+
+				scr.addContent(operation);
+				scr.addContent(id);
+				scr.addContent(scopedName);
+				coupledResource.addContent(scr);
+
+				// Add coupled resource before coupling type element
+				root.addContent(coupledResourceIdx, coupledResource);
+
+				// Add operatesOn element at the end of identification section.
+				Element op = new Element("operatesOn", srv);
+				op.setAttribute("uuidref", layer.uuid);
+
+				String hRefLink = dataMan.getSiteURL(context) + "/xml.metadata.get?uuid=" + layer.uuid;
+				op.setAttribute("href", hRefLink, xlink);
+
+				root.addContent(op);
+
+			}
+		}
+
+		return md;
+	}
+
+	/**
+	 * Add metadata for a Layer/FeatureType/Coverage element of a
+	 * GetCapabilities document. This function search for a metadataUrl element
+	 * (with @type = TC211 and format = text/xml) and try to load the XML
+	 * document. If failed, then an XSLT is used for creating metadata from the
+	 * Layer/FeatureType/Coverage element. If loaded document contain an
+	 * existing uuid, metadata will not be loaded in the catalogue.
+	 * 
+	 * @param layer
+	 *            Layer/FeatureType/Coverage element
+	 * @param capa
+	 *            GetCapabilities document
+	 * 
+	 * @return uuid
+	 * 
+	 */
+	private WxSLayerRegistry addLayerMetadata(Element layer, Element capa) throws JDOMException {
+		DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+		Date dt = new Date();
+		WxSLayerRegistry reg = new WxSLayerRegistry();
+		String schema;
+		String mdXml;
+		String date = df.format(dt);
+		// --- Loading stylesheet
+		String styleSheet = schemaMan.getSchemaDir(params.outputSchema) + Geonet.Path.CONVERT_STYLESHEETS
+				+ "/OGCWxSGetCapabilitiesto19119/" + "/OGC" + params.ogctype.substring(0, 3)
+				+ "GetCapabilitiesLayer-to-19139.xsl";
+		Element xml = null;
+
+		boolean exist;
+		boolean loaded = false;
+
+		if (params.ogctype.substring(0, 3).equals("WMS")) {
+			Element name;
+			if (params.ogctype.substring(3, 8).equals("1.3.0")) {
+				Namespace wms = Namespace.getNamespace("http://www.opengis.net/wms");
+				name = layer.getChild("Name", wms);
+			} else {
+				name = layer.getChild("Name");
+			}
+			// --- For the moment, skip non-requestable category layers
+			if (name == null || name.getValue().trim().equals("")) {
+				log.info("  - skipping layer with no name element");
+				return null;
+			}
+			reg.name = name.getValue();
+		} else if (params.ogctype.substring(0, 3).equals("WFS")) {
+			Namespace wfs = Namespace.getNamespace("http://www.opengis.net/wfs");
+			reg.name = layer.getChild("Name", wfs).getValue();
+		} else if (params.ogctype.substring(0, 3).equals("WCS")) {
+			Namespace wcs = Namespace.getNamespace("http://www.opengis.net/wcs");
+			reg.name = layer.getChild("name", wcs).getValue();
+		} else if (params.ogctype.substring(0, 3).equals("SOS")) {
+			Namespace gml = Namespace.getNamespace("http://www.opengis.net/gml");
+			reg.name = layer.getChild("name", gml).getValue();
+		}
+
+		log.info("  - Loading layer: " + reg.name);
+
+		// --- sha1 the full capabilities URL + the layer, coverage or feature
+		// name
+		reg.uuid = Sha1Encoder.encodeString(this.capabilitiesUrl + "#" + reg.name);
+
+		boolean wmsOrWfs = params.ogctype.substring(0, 3).equals("WMS") || params.ogctype.substring(0, 3).equals("WFS");
+
+		if (params.useLayerMd && !wmsOrWfs) {
+			log.info("  - MetadataUrl harvester only supported for WMS or WFS layers.");
+		}
+		// --- Trying to load metadataUrl element
+		if (params.useLayerMd && wmsOrWfs) {
+
+			Namespace xlink = Namespace.getNamespace("http://www.w3.org/1999/xlink");
+
+			// Get metadataUrl xlink:href
+			// TODO : add support for WCS metadataUrl element.
+
+			// Check if add namespace prefix to Xpath queries. If
+			// layer.getNamespace() is:
+			// * Namespace.NO_NAMESPACE, should not be added, otherwise
+			// exception is launched
+			// * Another namespace, should be added a namespace prefix to Xpath
+			// queries, otherwise doesn't find any result
+			String dummyNsPrefix = "";
+			boolean addNsPrefix = !layer.getNamespace().equals(Namespace.NO_NAMESPACE);
+			if (addNsPrefix)
+				dummyNsPrefix = "x:";
+
+			// WMS
+			if (params.ogctype.substring(0, 3).equals("WMS")) {
+
+				XPath mdUrl = XPath.newInstance("./" + dummyNsPrefix + "MetadataURL[@type='TC211' and " + dummyNsPrefix
+						+ "Format='text/xml']/" + dummyNsPrefix + "OnlineResource");
+				if (addNsPrefix)
+					mdUrl.addNamespace("x", layer.getNamespace().getURI());
+				Element onLineSrc = (Element) mdUrl.selectSingleNode(layer);
+
+				// Check if metadataUrl in WMS 1.3.0 format
+				if (onLineSrc == null) {
+					mdUrl = XPath.newInstance("./" + dummyNsPrefix + "MetadataURL[@type='ISO19115:2003' and "
+							+ dummyNsPrefix + "Format='text/xml']/" + dummyNsPrefix + "OnlineResource");
+					if (addNsPrefix)
+						mdUrl.addNamespace("x", layer.getNamespace().getURI());
+					onLineSrc = (Element) mdUrl.selectSingleNode(layer);
+				}
+
+				if (onLineSrc != null) {
+					org.jdom.Attribute href = onLineSrc.getAttribute("href", xlink);
+					if (href != null) {
+						mdXml = href.getValue();
+						try {
+							xml = retrieveExternalDocument(mdXml, false);
+
+							// If url is CSW GetRecordById remove envelope
+							if (xml.getName().equals("GetRecordByIdResponse")) {
+								xml = (Element) xml.getChildren().get(0);
+							}
+
+							schema = dataMan.autodetectSchema(xml, null);
+							// Extract uuid from loaded xml document
+							reg.uuid = dataMan.extractUUID(schema, xml);
+							exist = dataMan.existsMetadataUuid(dbms, reg.uuid);
+
+							if (exist) {
+								log.warning(
+										"    Metadata uuid already exist in the catalogue. Metadata will not be loaded.");
+								result.layerUuidExist++;
+								
+								// Return the layer info even if it exists in
+								// order to link to the service record.
+								return reg;
+							}
+
+							if (schema == null) {
+								log.warning(
+										"    Failed to detect schema from metadataUrl file. Use GetCapabilities document instead for that layer.");
+								result.unknownSchema++;
+								loaded = false;
+							} else {
+								log.info("  - Load layer metadataUrl document ok: " + mdXml);
+
+								loaded = true;
+								result.layerUsingMdUrl++;
+							}
+							// TODO : catch other exception
+						} catch (Exception e) {
+							log.warning("  - Failed to load layer using metadataUrl attribute : " + e.getMessage());
+							loaded = false;
+						}
+					} else {
+						log.info("  - No metadataUrl attribute with format text/xml found for that layer");
+						loaded = false;
+					}
+				} else {
+					log.info("  - No OnlineResource found for that layer");
+					loaded = false;
+				}
+			}
+			// WFS: there are no metadataUrl in WFS 1.0.0, we need to be in
+			// 1.1.0 specifically.
+			else if (params.ogctype.substring(0, 3).equals("WFS") && params.ogctype.substring(3, 8).equals("1.1.0")) {
+				try {
+					xml = getWfsMdFromMetadataUrl(layer);
+					// applying the same logic as above
+					if (xml.getName().equals("GetRecordByIdResponse")) {
+						xml = (Element) xml.getChildren().get(0);
+					}
+					schema = dataMan.autodetectSchema(xml, null);
+					reg.uuid = dataMan.extractUUID(schema, xml);
+					exist = dataMan.existsMetadataUuid(dbms, reg.uuid);
+					if (exist) {
+						log.warning("    Metadata uuid already exist in the catalogue. Metadata will not be loaded.");
+						result.layerUuidExist++;
+						return reg;
+					}
+					if (schema == null) {
+						log.warning(
+								"    Failed to detect schema from metadataUrl file. Use GetCapabilities document instead for that layer.");
+						result.unknownSchema++;
+						loaded = false;
+					} else {
+						loaded = true;
+						result.layerUsingMdUrl++;
+					}
+				} catch (Throwable e) {
+					log.error("  - Error trying to get the Metadata from the metadataUrl element (WFS): "
+							+ e.getMessage());
+					loaded = false;
+				}
+			}
+		}
+		// --- No metadataUrl along with the layer block: using the
+		// GetCapabilities document to generate a new MDD.
+		if (!loaded) {
+			try {
+				// --- set XSL param to filter on layer and set uuid
+				Map<String, String> param = new HashMap<String, String>();
+				param.put("uuid", reg.uuid);
+				param.put("Name", reg.name);
+				param.put("lang", params.lang);
+				param.put("topic", params.topic);
+				xml = Xml.transform(capa, styleSheet, param);
+				if (log.isDebugEnabled())
+					log.debug("  - Layer loaded using GetCapabilities document.");
+
+			} catch (Exception e) {
+				log.warning("  - Failed to do XSLT transformation on Layer element : " + e.getMessage());
+			}
+		}
+		// Insert or update metadata in database
+		try {
+
+			exist = dataMan.existsMetadataUuid(dbms, reg.uuid);
 			String group = null, isTemplate = null, docType = null, title = null, category = null;
 			boolean ufo = false, indexImmediate = false;
-			// MD does not exist yet
+
+			// At this point, the md variable contains:
+			//
+			// - a md retrieved remotely (via metadataUrl)
+			// - or a md generated by XSL transformation of the <Layer> block
+			//
+			// in either cases, the UUID (extracted from the retrieved MD - see
+			// line 598 (WMS) and 642 (WFS) or computed given the cap URL +
+			// layer name, line 539) can be used to determine if the MD is
+			// already in the catalogue.
+
+			//
+			// insert metadata
+			//
 			if (!exist) {
 				log.info("Metadata does not exist yet in the local catalogue, creating ...");
 				schema = dataMan.autodetectSchema(xml);
@@ -671,291 +729,296 @@ class Harvester extends BaseAligner {
 
 				if (log.isDebugEnabled())
 					log.debug("    - Set Harvested.");
-				 // FIXME: harvestUuid should be a SHA1 string
+				// FIXME: harvestUuid should be a SHA1 string
 				dataMan.setHarvestedExt(dbms, iId, params.uuid, params.url);
 			}
+			//
 			// Update MD
+			//
 			else {
 				log.info("Metadata already in local catalogue - updating data metadata");
-				String mdUuid = dataMan.getMetadataUuid(dbms, reg.uuid);
-				String oldHash = Sha1Encoder.encodeString(mdUuid);
+				Element curMd = dataMan.getMetadata(context, dataMan.getMetadataId(dbms, reg.uuid), false, false,
+						false);
+				String oldHash = Sha1Encoder.encodeString(Xml.getString(curMd));
 				String newHash = Sha1Encoder.encodeString(Xml.getString(xml));
 				if (oldHash.equals(newHash)) {
-					log.info("Computed / Fetched data metadata is the same as the one currently in database, skipping update");
+					log.info(
+							"Computed / Fetched data metadata is the same as the one currently in database, skipping update");
 				} else {
 
-					dataMan.updateMetadata(context, dbms, dataMan.getMetadataId(dbms, reg.uuid), xml,
-							false, ufo, indexImmediate, null, null, true);
-					// TODO: anything else to do ?
+					dataMan.updateMetadata(context, dbms, dataMan.getMetadataId(dbms, reg.uuid), xml, false, ufo,
+							indexImmediate, null, null, true);
 				}
 			}
-            dbms.commit();
+			dbms.commit();
 
-            dataMan.indexMetadata(dbms, reg.id);
+			dataMan.indexMetadata(dbms, reg.id);
 
-            try {
-                // Load bbox info for later use (eg. WMS thumbnails creation)
-                Namespace gmd = Namespace.getNamespace("http://www.isotc211.org/2005/gmd");
-                Namespace gco = Namespace.getNamespace("http://www.isotc211.org/2005/gco");
+			try {
+				// Load bbox info for later use (eg. WMS thumbnails creation)
+				Namespace gmd = Namespace.getNamespace("http://www.isotc211.org/2005/gmd");
+				Namespace gco = Namespace.getNamespace("http://www.isotc211.org/2005/gco");
 
-                ElementFilter bboxFinder = new ElementFilter("EX_GeographicBoundingBox", gmd);
-                @SuppressWarnings("unchecked")
-                Iterator<Element> bboxes = xml.getDescendants(bboxFinder);
+				ElementFilter bboxFinder = new ElementFilter("EX_GeographicBoundingBox", gmd);
+				@SuppressWarnings("unchecked")
+				Iterator<Element> bboxes = xml.getDescendants(bboxFinder);
 
-                while (bboxes.hasNext()) {
-                    Element box = bboxes.next();
-                    // FIXME : Could be null. Default bbox if from root layer
-                    reg.minx = Double.valueOf(box.getChild("westBoundLongitude", gmd).getChild("Decimal", gco)
-                            .getText());
-                    reg.miny = Double.valueOf(box.getChild("southBoundLatitude", gmd).getChild("Decimal", gco)
-                            .getText());
-                    reg.maxx = Double.valueOf(box.getChild("eastBoundLongitude", gmd).getChild("Decimal", gco)
-                            .getText());
-                    reg.maxy = Double.valueOf(box.getChild("northBoundLatitude", gmd).getChild("Decimal", gco)
-                            .getText());
+				while (bboxes.hasNext()) {
+					Element box = bboxes.next();
+					// FIXME : Could be null. Default bbox if from root layer
+					reg.minx = Double
+							.valueOf(box.getChild("westBoundLongitude", gmd).getChild("Decimal", gco).getText());
+					reg.miny = Double
+							.valueOf(box.getChild("southBoundLatitude", gmd).getChild("Decimal", gco).getText());
+					reg.maxx = Double
+							.valueOf(box.getChild("eastBoundLongitude", gmd).getChild("Decimal", gco).getText());
+					reg.maxy = Double
+							.valueOf(box.getChild("northBoundLatitude", gmd).getChild("Decimal", gco).getText());
 
-                }
-            } catch (Exception e) {
-                log.warning("  - Failed to extract layer bbox from metadata : " + e.getMessage());
-            }
+				}
+			} catch (Exception e) {
+				log.warning("  - Failed to extract layer bbox from metadata : " + e.getMessage());
+			}
 
-            result.layer++;
-            log.info("  - metadata loaded with uuid: " + reg.uuid + "/internal id: " + reg.id);
+			result.layer++;
+			log.info("  - metadata loaded with uuid: " + reg.uuid + "/internal id: " + reg.id);
 
-        } catch (Exception e) {
-            log.warning("  - Failed to load layer metadata : " + e.getMessage());
-            result.unretrievable++;
-            return null;
-        }
+		} catch (Exception e) {
+			log.warning("  - Failed to load layer metadata : " + e.getMessage());
+			result.unretrievable++;
+			e.printStackTrace();
+			return null;
+		}
 
-        return reg;
-    }
+		return reg;
+	}
 
-    /**
-     * 
-     * @param layer
-     * @return
-     */
-    private Element getWfsMdFromMetadataUrl(Element layer) throws Exception {
-        String dummyNsPrefix = "";
-        if (!layer.getNamespace().equals(Namespace.NO_NAMESPACE)) {
-            dummyNsPrefix = "x:";
-        }
-        XPath mdUrl = XPath.newInstance(String.format("./%sMetadataURL[@type='TC211' and @format='text/xml']/text()",
-                dummyNsPrefix));
+	/**
+	 * Given a WFS layer block, extract the metadata URL and retrieves it.
+	 *
+	 * @param layer the layer block from the WFS GetCapabilities response
+	 * @return Element the metadata fetched remotely.
+	 */
+	private Element getWfsMdFromMetadataUrl(Element layer) throws Exception {
+		String dummyNsPrefix = "";
+		if (!layer.getNamespace().equals(Namespace.NO_NAMESPACE)) {
+			dummyNsPrefix = "x:";
+		}
+		XPath mdUrl = XPath.newInstance(
+				String.format("./%sMetadataURL[@type='TC211' and @format='text/xml']/text()", dummyNsPrefix));
 
-        if (!layer.getNamespace().equals(Namespace.NO_NAMESPACE)) {
-            mdUrl.addNamespace("x", layer.getNamespace().getURI());
-        }
+		if (!layer.getNamespace().equals(Namespace.NO_NAMESPACE)) {
+			mdUrl.addNamespace("x", layer.getNamespace().getURI());
+		}
 
-        Text onLineSrc = (Text) mdUrl.selectSingleNode(layer);
+		Text onLineSrc = (Text) mdUrl.selectSingleNode(layer);
 
-        if (onLineSrc == null) {
-            throw new Exception("Online resource not found in the WFS XML fragment. Skipping.");
-        } else {
-            return Xml.loadFile(new URL(onLineSrc.getText()));
-        }
-    }
+		if (onLineSrc == null) {
+			throw new Exception("Online resource not found in the WFS XML fragment. Skipping.");
+		} else {
+			return retrieveExternalDocument(onLineSrc.getText(), false);
+		}
+	}
 
-    /**
-     * Call GeoNetwork service to load thumbnails and create small and big ones.
-     * 
-     * 
-     * @param layer
-     *            layer for which the thumbnail needs to be generated
-     * 
-     */
-    private void loadThumbnail(WxSLayerRegistry layer) {
-        if (log.isDebugEnabled())
-            log.debug("  - Creating thumbnail for layer metadata: " + layer.name + " id: " + layer.id);
-        Set s = new org.fao.geonet.services.thumbnail.Set();
+	/**
+	 * Call GeoNetwork service to load thumbnails and create small and big ones.
+	 * 
+	 * 
+	 * @param layer
+	 *            layer for which the thumbnail needs to be generated
+	 * 
+	 */
+	private void loadThumbnail(WxSLayerRegistry layer) {
+		if (log.isDebugEnabled())
+			log.debug("  - Creating thumbnail for layer metadata: " + layer.name + " id: " + layer.id);
+		Set s = new org.fao.geonet.services.thumbnail.Set();
 
-        try {
-            String filename = getMapThumbnail(layer);
+		try {
+			String filename = getMapThumbnail(layer);
 
-            if (filename != null) {
-                if (log.isDebugEnabled())
-                    log.debug("  - File: " + filename);
+			if (filename != null) {
+				if (log.isDebugEnabled())
+					log.debug("  - File: " + filename);
 
-                Element par = new Element("request");
-                par.addContent(new Element("id").setText(layer.id));
-                par.addContent(new Element("version").setText("10"));
-                par.addContent(new Element("type").setText("large"));
+				Element par = new Element("request");
+				par.addContent(new Element("id").setText(layer.id));
+				par.addContent(new Element("version").setText("10"));
+				par.addContent(new Element("type").setText("large"));
 
-                Element fname = new Element("fname").setText(filename);
-                fname.setAttribute("content-type", "image/png");
-                fname.setAttribute("type", "file");
-                fname.setAttribute("size", "");
+				Element fname = new Element("fname").setText(filename);
+				fname.setAttribute("content-type", "image/png");
+				fname.setAttribute("type", "file");
+				fname.setAttribute("size", "");
 
-                par.addContent(fname);
-                par.addContent(new Element("add").setText("Add"));
-                par.addContent(new Element("createSmall").setText("on"));
-                par.addContent(new Element("smallScalingFactor").setText("180"));
-                par.addContent(new Element("smallScalingDir").setText("width"));
+				par.addContent(fname);
+				par.addContent(new Element("add").setText("Add"));
+				par.addContent(new Element("createSmall").setText("on"));
+				par.addContent(new Element("smallScalingFactor").setText("180"));
+				par.addContent(new Element("smallScalingDir").setText("width"));
 
-                // Call the services
-                s.execOnHarvest(par, context, dbms, dataMan);
-                dbms.commit();
-                result.thumbnails++;
-            } else
-                result.thumbnailsFailed++;
-        } catch (Exception e) {
-            log.warning("  - Failed to set thumbnail for metadata: " + e.getMessage());
-            e.printStackTrace();
-            result.thumbnailsFailed++;
-        }
+				// Call the services
+				s.execOnHarvest(par, context, dbms, dataMan);
+				dbms.commit();
+				result.thumbnails++;
+			} else
+				result.thumbnailsFailed++;
+		} catch (Exception e) {
+			log.warning("  - Failed to set thumbnail for metadata: " + e.getMessage());
+			e.printStackTrace();
+			result.thumbnailsFailed++;
+		}
 
-    }
+	}
 
-    /**
-     * Remove thumbnails directory for all metadata FIXME : Do this only for
-     * existing one !
-     * 
-     * @param id
-     *            layer for which the thumbnail needs to be generated
-     * 
-     */
-    private void unsetThumbnail(String id) {
-        if (log.isDebugEnabled())
-            log.debug("  - Removing thumbnail for layer metadata: " + id);
+	/**
+	 * Remove thumbnails directory for all metadata FIXME : Do this only for
+	 * existing one !
+	 * 
+	 * @param id
+	 *            layer for which the thumbnail needs to be generated
+	 * 
+	 */
+	private void unsetThumbnail(String id) {
+		if (log.isDebugEnabled())
+			log.debug("  - Removing thumbnail for layer metadata: " + id);
 
-        try {
-            String file = Lib.resource.getDir(context, Params.Access.PUBLIC, id);
-            FileCopyMgr.removeDirectoryOrFile(new File(file));
-        } catch (Exception e) {
-            log.warning("  - Failed to remove thumbnail for metadata: " + id + ", error: " + e.getMessage());
-        }
-    }
+		try {
+			String file = Lib.resource.getDir(context, Params.Access.PUBLIC, id);
+			FileCopyMgr.removeDirectoryOrFile(new File(file));
+		} catch (Exception e) {
+			log.warning("  - Failed to remove thumbnail for metadata: " + id + ", error: " + e.getMessage());
+		}
+	}
 
-    /**
-     * Load thumbnails making a GetMap operation. Width is 300px. Ratio is
-     * computed for height using LatLongBoundingBoxElement.
-     * 
-     * 
-     * @param layer
-     *            layer for which the thumbnail needs to be generated
-     * 
-     */
-    private String getMapThumbnail(WxSLayerRegistry layer) {
-        String filename = layer.uuid + ".png";
-        String dir = context.getUploadDir();
-        Double r = WIDTH / (layer.maxx - layer.minx) * (layer.maxy - layer.miny);
+	/**
+	 * Load thumbnails making a GetMap operation. Width is 300px. Ratio is
+	 * computed for height using LatLongBoundingBoxElement.
+	 * 
+	 * 
+	 * @param layer
+	 *            layer for which the thumbnail needs to be generated
+	 * 
+	 */
+	private String getMapThumbnail(WxSLayerRegistry layer) {
+		String filename = layer.uuid + ".png";
+		String dir = context.getUploadDir();
+		Double r = WIDTH / (layer.maxx - layer.minx) * (layer.maxy - layer.miny);
 
-        // Usual GetMap url tested with mapserver and geoserver
-        // http://localhost:8080/geoserver/wms?service=WMS&request=GetMap&VERSION=1.1.1&
-        // LAYERS=gn:world&WIDTH=200&HEIGHT=200&FORMAT=image/png&BBOX=-180,-90,180,90&STYLES=
-        String url = getBaseUrl(params.url) + "&SERVICE=" + params.ogctype.substring(0, 3) + "&VERSION="
-                + params.ogctype.substring(3) + "&REQUEST=" + GETMAP + "&FORMAT=" + IMAGE_FORMAT + "&WIDTH=" + WIDTH
-                + "&SRS=EPSG:4326" + "&HEIGHT=" + r.intValue() + "&LAYERS=" + layer.name + "&STYLES=" + "&BBOX="
-                + layer.minx + "," + layer.miny + "," + layer.maxx + "," + layer.maxy;
-        // All is in Lat/Long epsg:4326
+		// Usual GetMap url tested with mapserver and geoserver
+		// http://localhost:8080/geoserver/wms?service=WMS&request=GetMap&VERSION=1.1.1&
+		// LAYERS=gn:world&WIDTH=200&HEIGHT=200&FORMAT=image/png&BBOX=-180,-90,180,90&STYLES=
+		String url = getBaseUrl(params.url) + "&SERVICE=" + params.ogctype.substring(0, 3) + "&VERSION="
+				+ params.ogctype.substring(3) + "&REQUEST=" + GETMAP + "&FORMAT=" + IMAGE_FORMAT + "&WIDTH=" + WIDTH
+				+ "&SRS=EPSG:4326" + "&HEIGHT=" + r.intValue() + "&LAYERS=" + layer.name + "&STYLES=" + "&BBOX="
+				+ layer.minx + "," + layer.miny + "," + layer.maxx + "," + layer.maxy;
+		// All is in Lat/Long epsg:4326
 
-        HttpClient httpclient = new HttpClient();
-        GetMethod req = new GetMethod(url);
+		HttpClient httpclient = new HttpClient();
+		GetMethod req = new GetMethod(url);
 
-        if (log.isDebugEnabled())
-            log.debug("Retrieving remote document: " + url);
+		if (log.isDebugEnabled())
+			log.debug("Retrieving remote document: " + url);
 
-        // set proxy from settings manager
-        Lib.net.setupProxy(context, httpclient);
+		// set proxy from settings manager
+		Lib.net.setupProxy(context, httpclient);
 
-        try {
-            // Connect
-            int result = httpclient.executeMethod(req);
-            if (log.isDebugEnabled())
-                log.debug("   Get " + result);
+		try {
+			// Connect
+			int result = httpclient.executeMethod(req);
+			if (log.isDebugEnabled())
+				log.debug("   Get " + result);
 
-            if (result == 200) {
-                // Save image document to temp directory
-                // TODO: Check OGC exception
-                OutputStream fo = null;
-                InputStream in = null;
+			if (result == 200) {
+				// Save image document to temp directory
+				// TODO: Check OGC exception
+				OutputStream fo = null;
+				InputStream in = null;
 
-                try {
-                    fo = new FileOutputStream(dir + filename);
-                    in = req.getResponseBodyAsStream();
-                    BinaryFile.copy(in, fo);
-                } finally {
-                    IOUtils.closeQuietly(in);
-                    IOUtils.closeQuietly(fo);
-                }
-            } else {
-                log.info(" Http error connecting");
-                return null;
-            }
-        } catch (HttpException he) {
-            log.info(" Http error connecting to '" + httpclient.toString() + "'");
-            log.info(he.getMessage());
-            return null;
-        } catch (IOException ioe) {
-            log.info(" Unable to connect to '" + httpclient.toString() + "'");
-            log.info(ioe.getMessage());
-            return null;
-        } finally {
-            // Release current connection to the connection pool once you are
-            // done
-            req.releaseConnection();
-        }
+				try {
+					fo = new FileOutputStream(dir + filename);
+					in = req.getResponseBodyAsStream();
+					BinaryFile.copy(in, fo);
+				} finally {
+					IOUtils.closeQuietly(in);
+					IOUtils.closeQuietly(fo);
+				}
+			} else {
+				log.info(" Http error connecting");
+				return null;
+			}
+		} catch (HttpException he) {
+			log.info(" Http error connecting to '" + httpclient.toString() + "'");
+			log.info(he.getMessage());
+			return null;
+		} catch (IOException ioe) {
+			log.info(" Unable to connect to '" + httpclient.toString() + "'");
+			log.info(ioe.getMessage());
+			return null;
+		} finally {
+			// Release current connection to the connection pool once you are
+			// done
+			req.releaseConnection();
+		}
 
-        return filename;
-    }
+		return filename;
+	}
 
-    /**
-     * Add '?' or '&' if required to url so that parameters can just be appended
-     * to it
-     * 
-     * @param url
-     *            Url to which parameters are going to be appended
-     * 
-     */
-    private String getBaseUrl(String url) {
-        if (url.endsWith("?")) {
-            return url;
-        } else if (url.contains("?")) {
-            return url + "&";
-        } else {
-            return url + "?";
-        }
-    }
+	/**
+	 * Add '?' or '&' if required to url so that parameters can just be appended
+	 * to it
+	 * 
+	 * @param url
+	 *            Url to which parameters are going to be appended
+	 * 
+	 */
+	private String getBaseUrl(String url) {
+		if (url.endsWith("?")) {
+			return url;
+		} else if (url.contains("?")) {
+			return url + "&";
+		} else {
+			return url + "?";
+		}
+	}
 
-    // ---------------------------------------------------------------------------
-    // ---
-    // --- Variables
-    // ---
-    // ---------------------------------------------------------------------------
+	// ---------------------------------------------------------------------------
+	// ---
+	// --- Variables
+	// ---
+	// ---------------------------------------------------------------------------
 
-    private Logger log;
-    private ServiceContext context;
-    private Dbms dbms;
-    private OgcWxSParams params;
-    private DataManager dataMan;
-    private SchemaManager schemaMan;
-    private CategoryMapper localCateg;
-    private GroupMapper localGroups;
-    private HarvestResult result;
+	private Logger log;
+	private ServiceContext context;
+	private Dbms dbms;
+	private OgcWxSParams params;
+	private DataManager dataMan;
+	private SchemaManager schemaMan;
+	private CategoryMapper localCateg;
+	private GroupMapper localGroups;
+	private HarvestResult result;
 
-    /**
-     * Store the GetCapabilities operation URL. This URL is scrambled and used
-     * to uniquelly identified the service. The idea of generating a uuid based
-     * on the URL instead of a randomuuid is to be able later to do an update of
-     * the service metadata (which could have been updated in the catalogue)
-     * instead of a delete/insert operation.
-     */
-    private String capabilitiesUrl;
-    private static final int WIDTH = 900;
-    private static final String GETCAPABILITIES = "GetCapabilities";
-    private static final String GETMAP = "GetMap";
-    private static final String IMAGE_FORMAT = "image/png";
-    private List<WxSLayerRegistry> layersRegistry = new ArrayList<WxSLayerRegistry>();
+	/**
+	 * Store the GetCapabilities operation URL. This URL is scrambled and used
+	 * to uniquelly identified the service. The idea of generating a uuid based
+	 * on the URL instead of a randomuuid is to be able later to do an update of
+	 * the service metadata (which could have been updated in the catalogue)
+	 * instead of a delete/insert operation.
+	 */
+	private String capabilitiesUrl;
+	private static final int WIDTH = 900;
+	private static final String GETCAPABILITIES = "GetCapabilities";
+	private static final String GETMAP = "GetMap";
+	private static final String IMAGE_FORMAT = "image/png";
+	private List<WxSLayerRegistry> layersRegistry = new ArrayList<WxSLayerRegistry>();
 
-    private static class WxSLayerRegistry {
-        public String uuid;
-        public String id;
-        public String name;
-        public Double minx = -180.0;
-        public Double miny = -90.0;
-        public Double maxx = 180.0;
-        public Double maxy = 90.0;
-    }
+	private static class WxSLayerRegistry {
+		public String uuid;
+		public String id;
+		public String name;
+		public Double minx = -180.0;
+		public Double miny = -90.0;
+		public Double maxx = 180.0;
+		public Double maxy = 90.0;
+	}
 
 }

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/convert/OGCWxSGetCapabilitiesto19119/identification.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/convert/OGCWxSGetCapabilitiesto19119/identification.xsl
@@ -335,7 +335,7 @@
 									</xsl:variable>
 											
 									<westBoundLongitude>
-										<gco:Decimal><xsl:copy-of select="math:min(exslt:node-set($boxes)/*[name(.)='xmin'])"/></gco:Decimal>
+										<gco:Decimal><xsl:value-of select="math:min(exslt:node-set($boxes)/*[name(.)='xmin'])"/></gco:Decimal>
 									</westBoundLongitude>
 									<eastBoundLongitude>
 										<gco:Decimal><xsl:value-of select="math:max(exslt:node-set($boxes)/*[name(.)='xmax'])"/></gco:Decimal>

--- a/web/src/main/webapp/xsl/conversion/OGCWxSGetCapabilitiesto19119/identification.xsl
+++ b/web/src/main/webapp/xsl/conversion/OGCWxSGetCapabilitiesto19119/identification.xsl
@@ -600,7 +600,7 @@
 									</xsl:variable>
 											
 									<westBoundLongitude>
-										<gco:Decimal><xsl:copy-of select="exslt:node-set($boxes)/*[name(.)='xmin']"/></gco:Decimal>
+										<gco:Decimal><xsl:value-of select="exslt:node-set($boxes)/*[name(.)='xmin']"/></gco:Decimal>
 									</westBoundLongitude>
 									<eastBoundLongitude>
 										<gco:Decimal><xsl:value-of select="exslt:node-set($boxes)/*[name(.)='xmax']"/></gco:Decimal>

--- a/web/src/test/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/HarvesterTest.java
+++ b/web/src/test/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/HarvesterTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ArrayList;
@@ -68,6 +69,9 @@ public class HarvesterTest {
 		Harvester h = new Harvester(null, ctx, null, null);
 		Method m = ReflectionUtils.findMethod(h.getClass(), "getWfsMdFromMetadataUrl", Element.class);
 		m.setAccessible(true);
+		Field f = ReflectionUtils.findField(h.getClass(), "allowLocalRetrieval");
+		f.setAccessible(true);
+		f.setBoolean(h, true);
 		
 		Element xml = (Element) ReflectionUtils.invokeMethod(m, h, featureType);
 
@@ -111,6 +115,9 @@ public class HarvesterTest {
 		Harvester h = new Harvester(null, ctx, null, null);
 		Method m = ReflectionUtils.findMethod(h.getClass(), "getWfsMdFromMetadataUrl", Element.class);
 		m.setAccessible(true);
+		Field f = ReflectionUtils.findField(h.getClass(), "allowLocalRetrieval");
+		f.setAccessible(true);
+		f.setBoolean(h, true);
 
 		boolean fileNotFoundExCaught = false;
 		try {
@@ -119,6 +126,6 @@ public class HarvesterTest {
 			Throwable e1 = e.getCause();
 			fileNotFoundExCaught = e1 instanceof FileNotFoundException;
 		}
-		assertTrue("No exception caught, expected one (no MdUrl found)", fileNotFoundExCaught);
+		assertTrue("Expected a FileNotFoundException (no MdUrl found)", fileNotFoundExCaught);
 	}	
 }


### PR DESCRIPTION
WxS harvesting - Do not remove MDD across harvests:
- The Service metadata generated for the WxS harvested node is still deleted / recreated, because it is more simpler than having to sweep off child MD references. Note: the uuid is computed from the GetCapabilities URL, so it is supposed to be stable.
- MDD still present in the catalogue but not in the remote getcapabilities response are removed at the end of the process.
- the update process might require a little bit more testing.

Tests: Due to the current state of the code (and the complexity of the dynamic aspects of a complete testsuite for such usecases), it would have required a complete rewrite to allow better testing, I could not
manage to make it more testable than the introduced HarvesterTest.java class. the code has been runtime tested (onto Geopicardie WMS + WFS), and should be pretty safe though.

Portability node: porting the current code into GN3 will require at least 3 extra days of work, and might be the occasion to rewrite the harvester  a more testable fashion. For now, I consider keeping it "geOrchestra-specific".

Extra infos (not directly related to the purpose of this PR): The User-Agent in this branch is customized to avoid triggering the Basic-auth onto geOrchestra remote services.

Should address the following issues:
camptocamp/georchestra-cigalsace-configuration#340
camptocamp/georchestra-geopicardie-configuration#411
