### PR TITLE
Add sample config to override datadir paths via geonetwork.properties

### DIFF
--- a/web/src/deb/resources/etc/georchestra/geonetwork/config/config-datadir-georchestra.xml
+++ b/web/src/deb/resources/etc/georchestra/geonetwork/config/config-datadir-georchestra.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans default-lazy-init="true"
+  xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xsi:schemaLocation="
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+  <context:property-placeholder location="file:${georchestra.datadir}/geonetwork/geonetwork.properties" file-encoding="UTF-8" ignore-unresolvable="true" order="0"/>
+
+  <bean id="GeonetworkDataDirectory" class="org.fao.geonet.kernel.GeonetworkDataDirectory" lazy-init="true">
+    <property name="systemDataDir" ref="GNSystemDataDir"/>
+    <property name="schemaPluginsDir" ref="GNSchemaPluginsDir"/>
+    <property name="spatialIndexPath" ref="GNSpatialIndexPath"/>
+    <property name="configDir" ref="GNConfigDir"/>
+    <property name="luceneDir" ref="GNLuceneDir"/>
+    <property name="thesauriDir" ref="GNThesauriDir"/>
+    <property name="metadataDataDir" ref="GNMetadataDataDir"/>
+    <property name="metadataRevisionDir" ref="GNMetadataRevisionDir"/>
+    <property name="resourcesDir" ref="GNResourcesDir"/>
+    <property name="htmlCacheDir" ref="GNHtmlCacheDir"/>
+    <property name="uploadDir" ref="GNUploadDir"/>
+    <property name="formatterDir" ref="GNFormatterDir"/>
+  </bean>
+  <bean id="GNSystemDataDir" class="java.nio.file.Paths" factory-method="get">
+    <constructor-arg index="0" value="${geonetwork.dir}"/>
+    <constructor-arg index="1"><array /></constructor-arg>
+  </bean>
+  <bean id="GNSchemaPluginsDir" class="java.nio.file.Paths" factory-method="get">
+    <constructor-arg index="0" value="${geonetwork.schema.dir}"/>
+    <constructor-arg index="1"><array /></constructor-arg>
+  </bean>
+  <bean id="GNSpatialIndexPath" class="java.nio.file.Paths" factory-method="get">
+    <constructor-arg index="0" value="${geonetwork.spatial.dir}"/>
+    <constructor-arg index="1"><array /></constructor-arg>
+  </bean>
+  <bean id="GNConfigDir" class="java.nio.file.Paths" factory-method="get">
+    <constructor-arg index="0" value="${geonetwork.config.dir}"/>
+    <constructor-arg index="1"><array /></constructor-arg>
+  </bean>
+  <bean id="GNLuceneDir" class="java.nio.file.Paths" factory-method="get">
+    <constructor-arg index="0" value="${geonetwork.lucene.dir}"/>
+    <constructor-arg index="1"><array /></constructor-arg>
+  </bean>
+  <bean id="GNThesauriDir" class="java.nio.file.Paths" factory-method="get">
+    <constructor-arg index="0" value="${geonetwork.thesauri.dir}"/>
+    <constructor-arg index="1"><array /></constructor-arg>
+  </bean>
+  <bean id="GNMetadataDataDir" class="java.nio.file.Paths" factory-method="get">
+    <constructor-arg index="0" value="${geonetwork.data.dir}"/>
+    <constructor-arg index="1"><array /></constructor-arg>
+  </bean>
+  <bean id="GNMetadataRevisionDir" class="java.nio.file.Paths" factory-method="get">
+    <constructor-arg index="0" value="${geonetwork.svn.dir}"/>
+    <constructor-arg index="1"><array /></constructor-arg>
+  </bean>
+  <bean id="GNResourcesDir" class="java.nio.file.Paths" factory-method="get">
+    <constructor-arg index="0" value="${geonetwork.resources.dir}"/>
+    <constructor-arg index="1"><array /></constructor-arg>
+  </bean>
+  <bean id="GNHtmlCacheDir" class="java.nio.file.Paths" factory-method="get">
+    <constructor-arg index="0" value="${geonetwork.htmlcache.dir}"/>
+    <constructor-arg index="1"><array /></constructor-arg>
+  </bean>
+  <bean id="GNUploadDir" class="java.nio.file.Paths" factory-method="get">
+    <constructor-arg index="0" value="${geonetwork.upload.dir}"/>
+    <constructor-arg index="1"><array /></constructor-arg>
+  </bean>
+  <bean id="GNFormatterDir" class="java.nio.file.Paths" factory-method="get">
+    <constructor-arg index="0" value="${geonetwork.formatter.dir}"/>
+    <constructor-arg index="1"><array /></constructor-arg>
+  </bean>
+
+</beans>

--- a/web/src/deb/resources/etc/georchestra/geonetwork/config/config-overrides-georchestra.xml
+++ b/web/src/deb/resources/etc/georchestra/geonetwork/config/config-overrides-georchestra.xml
@@ -4,6 +4,7 @@
     <!-- earlier imported from config-security/config-security.xml -->
     <import file="${env:georchestra.datadir}/geonetwork/config/config-security-georchestra.xml" />
     <import file="${env:georchestra.datadir}/geonetwork/config/config-db-georchestra.xml" />
+    <import file="${env:georchestra.datadir}/geonetwork/config/config-datadir-georchestra.xml" />
     <import file="${env:georchestra.datadir}/geonetwork/config/config-logging-georchestra.xml" />
   </spring>
 </overrides>

--- a/web/src/deb/resources/etc/georchestra/geonetwork/geonetwork.properties
+++ b/web/src/deb/resources/etc/georchestra/geonetwork/geonetwork.properties
@@ -1,3 +1,17 @@
+# geonetwork datadir subdirs
+geonetwork.dir=/path/to/your/geonetwork_data_dir
+geonetwork.config.dir=${geonetwork.dir}/config/
+geonetwork.schema.dir=${geonetwork.config.dir}/schema_plugins/
+geonetwork.lucene.dir=${geonetwork.dir}/index/
+geonetwork.spatial.dir=${geonetwork.lucene.dir}
+geonetwork.thesauri.dir=${geonetwork.config.dir}/codelist/
+geonetwork.data.dir=${geonetwork.dir}/data/metadata_data/
+geonetwork.svn.dir=${geonetwork.dir}/data/metadata_subversion/
+geonetwork.resources.dir=${geonetwork.dir}/data/resources/
+geonetwork.upload.dir=${geonetwork.dir}/data/upload/
+geonetwork.formatter.dir=${geonetwork.dir}/data/formatter/
+geonetwork.htmlcache.dir=${geonetwork.resources.dir}/htmlcache/
+
 # database configuration
 jdbc.host=localhost
 jdbc.port=5432

--- a/web/src/deb/resources/etc/georchestra/geonetwork/geonetwork.properties
+++ b/web/src/deb/resources/etc/georchestra/geonetwork/geonetwork.properties
@@ -1,5 +1,5 @@
 # geonetwork datadir subdirs
-geonetwork.dir=/path/to/your/geonetwork_data_dir
+geonetwork.dir=/tmp/gn_data
 geonetwork.config.dir=${geonetwork.dir}/config/
 geonetwork.schema.dir=${geonetwork.config.dir}/schema_plugins/
 geonetwork.lucene.dir=${geonetwork.dir}/index/


### PR DESCRIPTION
Todo: amend configs/docs in georchestra/georchestra where tomcat config mentions -Dgeonetwork.dir and -Dgeonetwork.schema.dir, only doc/setup/tomcat.md ?
