### PR TITLE
disable map by default

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -654,7 +654,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES
   ('map/proj4js', '[{"code":"EPSG:2154","value":"+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"}]', 0, 9591, 'n');
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES
-  ('map/isMapViewerEnabled', 'true', 2, 9592, 'n');
+  ('map/isMapViewerEnabled', 'false', 2, 9592, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES
   ('map/is3DModeAllowed', 'false', 2, 9593, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v300/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v300/migrate-default.sql
@@ -10,7 +10,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/atomProtocol', 'INSPIRE-ATOM', 0, 7250, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadata/prefergrouplogo', 'true', 2, 9111, 'y');
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('map/isMapViewerEnabled', 'true', 2, 9592, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('map/isMapViewerEnabled', 'false', 2, 9592, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadata/allThesaurus', 'false', 2, 9160, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/ui/defaultView', 'georchestra', 0, 10100, 'n');
 


### PR DESCRIPTION
In geOrchestra, the gn3 viewer is redundant with mapfishapp.

People who want the map will still be able to enable it from the admin ui.
