### PR TITLE
gn2 - dockerization

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -1162,6 +1162,42 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>docker</id>
+      <properties>
+        <dockerImageName>georchestra/${project.parent.artifactId}</dockerImageName>
+      </properties>
+      <build>
+        <finalName>geonetwork</finalName>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>0.3.8</version>
+            <configuration>
+              <imageName>${dockerImageName}</imageName>
+              <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
+              <resources>
+                <resource>
+                  <targetPath>/usr/local/tomcat/webapps</targetPath>
+                  <directory>${project.build.directory}</directory>
+                  <include>${project.parent.artifactId}.war</include>
+                </resource>
+              </resources>
+              <serverId>docker-hub</serverId>
+              <registryUrl>https://index.docker.io/v1/</registryUrl>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>19.0</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
   <reporting>
     <plugins>

--- a/web/src/docker/Dockerfile
+++ b/web/src/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM tomcat:8.0-jre8
+
+RUN rm -rf /usr/local/tomcat/webapps/*
+ADD . /
+
+

--- a/web/src/docker/usr/local/tomcat/bin/setenv.sh
+++ b/web/src/docker/usr/local/tomcat/bin/setenv.sh
@@ -1,0 +1,1 @@
+export CATALINA_OPTS="$CATALINA_OPTS  -Dgeonetwork.jeeves.configuration.overrides.file=/usr/local/tomcat/webapps/geonetwork/WEB-INF/config-overrides-georchestra.xml -Dgeonetwork.dir=/usr/local/tomcat/work/gn_data -Dgeonetwork-private.schema.dir=/srv/tomcat/tomcat1/webapps/geonetwork-private/WEB-INF/data/config/schema_plugins"


### PR DESCRIPTION
Contrary to the other webapps in georchestra, we need to use tomcat,
because we can predict where the webapp will be unzipped
(/usr/local/tomcat/webapps/geonetwork/). This is not the case with
Jetty, which unzips into /tmp and uses a timestamp in the generated
directory.

The need to know where the file will be available comes from the fact
that we use an env variable for the jeeves overrides file which is
nested into the webapp (see the added setenv.sh file from this commit
for more details).

Tests: manually on pigma dev.

The same convention applies for the generated image, e.g. you can use
-DdockerImageName=myorg/mygeonetwork2:tag as maven property.
