### PR TITLE
GN2 - rework on dockerization

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -1179,7 +1179,7 @@
               <dockerDirectory>${project.basedir}/src/docker</dockerDirectory>
               <resources>
                 <resource>
-                  <targetPath>/usr/local/tomcat/webapps</targetPath>
+                  <targetPath>/var/lib/jetty/webapps</targetPath>
                   <directory>${project.build.directory}</directory>
                   <include>${project.parent.artifactId}.war</include>
                 </resource>

--- a/web/src/docker/Dockerfile
+++ b/web/src/docker/Dockerfile
@@ -1,6 +1,20 @@
-FROM tomcat:8.0-jre8
+FROM jetty:9.3-jre8
 
-RUN rm -rf /usr/local/tomcat/webapps/*
 ADD . /
 
+RUN apt-get update && \
+    apt-get install -y unzip && \
+    rm -rf /var/lib/apt/lists/*
 
+VOLUME [ "/var/local/geonetwork" ]
+
+RUN unzip /var/lib/jetty/webapps/geonetwork.war -d /var/lib/jetty/webapps/geonetwork && \
+  rm -f /var/lib/jetty/webapps/geonetwork.war && \
+  chown -R jetty:jetty /var/lib/jetty/webapps/geonetwork
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "java","-Djava.io.tmpdir=/tmp/jetty",                                                                                             \
+      "-Dgeonetwork.jeeves.configuration.overrides.file=/var/lib/jetty/webapps/geonetwork/WEB-INF/config-overrides-georchestra.xml",    \
+      "-Dgeonetwork.dir=/var/local/geonetwork",                                                                                         \
+      "-Dgeonetwork-private.schema.dir=/var/lib/jetty/webapps/geonetwork/WEB-INF/data/config/schema_plugins",                           \
+      "-jar","/usr/local/jetty/start.jar" ]

--- a/web/src/docker/docker-entrypoint.d/00-adjust-perms
+++ b/web/src/docker/docker-entrypoint.d/00-adjust-perms
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+chown -R jetty:jetty /var/local/geonetwork
+

--- a/web/src/docker/docker-entrypoint.sh
+++ b/web/src/docker/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+DIR=/docker-entrypoint.d
+
+if [[ -d "$DIR" ]]
+then
+  /bin/run-parts --verbose "$DIR"
+fi
+
+exec "$@"

--- a/web/src/docker/usr/local/tomcat/bin/setenv.sh
+++ b/web/src/docker/usr/local/tomcat/bin/setenv.sh
@@ -1,1 +1,0 @@
-export CATALINA_OPTS="$CATALINA_OPTS  -Dgeonetwork.jeeves.configuration.overrides.file=/usr/local/tomcat/webapps/geonetwork/WEB-INF/config-overrides-georchestra.xml -Dgeonetwork.dir=/var/local/geonetwork -Dgeonetwork-private.schema.dir=/usr/local/tomcat/webapps/geonetwork/WEB-INF/data/config/schema_plugins"


### PR DESCRIPTION
Following previous work:
- Migrating to jetty (tomcat images are running the servlet container as root ...)
- Adding a volume decl on /var/local/geonetwork
- Introducing docker-entrypoint.d/ to adjust volume rights

Migrating to Jetty allows to stay coherent with the rest of the geOrchestra docker conventions
