### PR TITLE
maven - fixing maven profile conflict with geOrchestra

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1151,6 +1151,10 @@
     <module>services</module>
     <module>wro4j</module>
     <module>inspire-atom</module>
+    <module>web-ui</module>
+    <module>web-ui-docs</module>
+    <module>web-client</module>
+    <module>web</module>
   </modules>
 
   <profiles>
@@ -1163,10 +1167,6 @@
       </activation>
       <modules>
         <module>schemas-test</module>
-        <module>web-ui</module>
-        <module>web-ui-docs</module>
-        <module>web-client</module>
-        <module>web</module>
         <module>e2e-tests</module>
         <module>geoserver</module>
       </modules>


### PR DESCRIPTION
Some people use the `-P-all` profile which has a specific meaning in the geOrchestra build, see:
https://github.com/georchestra/georchestra/blob/16.12/pom.xml#L384-L409

But using `-P-all` affects geonetwork build in a strange manner, since it means "skip the build of the following modules: schemas-test, web-ui, web-ui-docs, web-client, web, e2e-tests, geoserver". We do need web, which is the module responsible of building the webapp.

the definition of the "all" profile is also weird in GN because it is activated by default when the root pom of geonetwork exists which is likely to be the case. I guess we can consider that the added default module from this PR are acceptable.

This fix should also be ported to other `georchestra-gn3-*` branches.

Tests: Runtime (well, compilation) tests on rennes-metropole.
 