### PR TITLE
Dbms - reopens connection if it is detected as closed

### DIFF
--- a/jeeves/src/main/java/jeeves/resources/dbms/Dbms.java
+++ b/jeeves/src/main/java/jeeves/resources/dbms/Dbms.java
@@ -208,6 +208,13 @@ public class Dbms
 		PreparedStatement stmt = null;
 		ResultSet resultSet = null;
 
+		// Fixing connection issues: if connection has been closed, then ask for a new one.
+		// This fix is meant to address harvesting issues in case of the database server is
+		// closing connections. This has been encountered on CIGAL & PIGMA platforms.
+		if (conn.isClosed()) {
+		    conn = dataSource.getConnection();
+		}
+
 		try
 		{
 		    stmt = conn.prepareStatement(query);


### PR DESCRIPTION
This should fix legacy GN2 DB connection management while trying to harvest remote nodes, see following (private) issues:

* https://github.com/camptocamp/georchestra-pigma-configuration/issues/521
* https://github.com/camptocamp/georchestra-cigalsace-configuration/issues/759

Nothing tested, just a wild guess that it should work ...