### PR TITLE
Fix failed docker build because upstream image change

### DIFF
--- a/web/src/docker/Dockerfile
+++ b/web/src/docker/Dockerfile
@@ -6,9 +6,15 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
 ADD . /
 
+# Temporary switch to root
+USER root
+
 RUN mkdir /mnt/geonetwork_datadir && \
     chown jetty:jetty /etc/georchestra /mnt/geonetwork_datadir && \
     chown -R jetty:jetty /var/lib/jetty/webapps
+
+# Restore jetty user
+USER jetty
 
 VOLUME [ "/mnt/geonetwork_datadir", "/tmp", "/run/jetty" ]
 


### PR DESCRIPTION
New jetty docker image now set user as jetty also for build step, so we
cannot add package. This commit temporary switch to root user for
installaing packages.
See :
appropriate/docker-jetty@19b4331#diff-dad6c4a2a53860754faaf15e201d8b0d