### PR TITLE
Adding a SSL-aware postgis datastore factory for GeoTools

### DIFF
--- a/web/src/main/java/org/georchestra/PostgisNGSSLDataStoreFactory.java
+++ b/web/src/main/java/org/georchestra/PostgisNGSSLDataStoreFactory.java
@@ -1,0 +1,26 @@
+package org.georchestra;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.geotools.data.postgis.PostgisNGDataStoreFactory;
+
+
+public class PostgisNGSSLDataStoreFactory extends PostgisNGDataStoreFactory {
+
+    private final static String SSL = "ssl";
+
+    private final static String SSL_FACTORY = "sslfactory";
+
+    @Override
+    protected String getJDBCUrl(Map params) throws IOException {
+        String jdbcUrl = super.getJDBCUrl(params);
+        if (params.containsKey(SSL)) {
+            jdbcUrl += "?ssl=" + params.get(SSL);
+            if (params.containsKey(SSL_FACTORY)) {
+                jdbcUrl += "&sslfactory=" + params.get(SSL_FACTORY);
+            }
+        }
+        return jdbcUrl;
+    }
+}


### PR DESCRIPTION
Adding a class to enable ssl capabilities for the spatial indexes when these are stored in a PostGIS db, you should then be able to modify the configuration in https://github.com/georchestra/datadir/blob/17.12/geonetwork/config/config-db-georchestra.xml#L67-L94 adding these two map entries:

```xml
  <bean id="datastoreFactory" class="org.georchestra.PostgisNGSSLDataStoreFactory"/>
[...]
        <entry key="ssl" value="true"/>
        <entry key="sslfactory" value="org.postgresql.ssl.NonValidatingFactory"/>
```

This can be needed in case of a PostGreSQL server with SSL option mandatory. Note: the 2nd entry in the map is only needed if the SSL certificate used by the remote PostGres is self-signed (which is often the case actually).

