### PR TITLE
Remove hardcoded webapp path

### DIFF
--- a/core/src/main/java/org/fao/geonet/web/LocaleRedirects.java
+++ b/core/src/main/java/org/fao/geonet/web/LocaleRedirects.java
@@ -88,7 +88,7 @@ public class LocaleRedirects {
                 redirectURL.append("&" + originalRequest.getQueryString());
             }
         } catch(ClassCastException ex){
-            redirectURL = new StringBuilder("/geonetwork/?login");
+            redirectURL = new StringBuilder(request.getContextPath() + "/?login");
         }
         return redirectURL(redirectURL.toString());
     }


### PR DESCRIPTION


Remove hardcoded path introduce in #58, instead it use `request.getContextPath()`