### PR TITLE
Bumping versions of frontend-maven-plugin, node and npm

### DIFF
--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -192,7 +192,7 @@
           <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
-            <version>0.0.11</version>
+            <version>1.6</version>
 
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1322,8 +1322,8 @@
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
     <rootProjectDir>..</rootProjectDir>
     <wro.version>1.7.7</wro.version>
-    <node.version>v0.10.24</node.version>
-    <npm.version>1.3.23</npm.version>
+    <node.version>v8.11.1</node.version>
+    <npm.version>5.8.0</npm.version>
     <xmlunit.version>2.1.1</xmlunit.version>
     <print-lib.version>2.1.1</print-lib.version>
     <flying-saucer>9.0.7</flying-saucer>

--- a/web-ui-docs/pom.xml
+++ b/web-ui-docs/pom.xml
@@ -16,7 +16,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>0.0.23</version>
+        <version>1.6</version>
         <executions>
           <execution>
             <id>install node and npm</id>


### PR DESCRIPTION
We currently have an issue with the web-ui-docs module in a certain context (source-to-image / centOS based docker container), some issues in node / npm suggest to update the version, which is what I am
currently trying.

Tests: only tested at compilation level, seems OK with a regular clean / install maven invocation.