### PR TITLE
set project.packageVersion depending on project.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1318,7 +1318,7 @@
     <spring.version>4.2.4.RELEASE</spring.version>
     <spring.security.version>3.2.0.RELEASE</spring.security.version>
     <metrics.version>2.1.1</metrics.version>
-    <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
+    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
     <rootProjectDir>..</rootProjectDir>
     <wro.version>1.7.7</wro.version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -585,6 +585,7 @@
 								<includeOnlyProperty>^git.tags$</includeOnlyProperty>
 								<includeOnlyProperty>^git.branch$</includeOnlyProperty>
 								<includeOnlyProperty>^git.commit.id$</includeOnlyProperty>
+								<includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
 								<includeOnlyProperty>^git.commit.id.describe.short$</includeOnlyProperty>
 								<includeOnlyProperty>^git.build.time$</includeOnlyProperty>
 							</includeOnlyProperties>
@@ -1011,6 +1012,23 @@
                 </configuration>
                 <goals><goal>run</goal></goals>
               </execution>
+              <execution>
+                <id>set-project-packageversion</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <exportAntProperties>true</exportAntProperties>
+                  <target>
+                    <condition property="project.packageVersion"
+                      value="99.master.${maven.build.timestamp}~${git.commit.id.abbrev}"
+                      else="${project.version}.${maven.build.timestamp}~${git.commit.id.abbrev}">
+                      <matches string="${project.version}" pattern="SNAPSHOT$" />
+                    </condition>
+                  </target>
+               </configuration>
+            </execution>
             </executions>
           </plugin>
           <plugin>
@@ -1021,7 +1039,6 @@
               <packageName>georchestra-geonetwork3</packageName>
               <packageDescription>Debian package for the GeoNetwork fork of geOrchestra.</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectUrl>http://www.georchestra.org/</projectUrl>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>


### PR DESCRIPTION
* cf georchestra/georchestra#1931, adapted from georchestra/georchestra@f592151
* stop setting packageRevision, reprepro doesnt handle it
* remove the dash in the timestamp format
* include git.commit.id.abbrev in the properties generated by the git-commitid-plugin

This finally generates georchestra-geonetwork3_3.4.1-0.201806270709~0fcd5e0-1_all.deb
and dpkg --info says 'Version: 3.4.1-0.201806270709~0fcd5e0'