### PR TITLE
Properly set packageVersion (georchestra/georchestra#1931)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1201,7 +1201,7 @@
     <spring.version>3.2.5.RELEASE</spring.version>
     <spring.security.version>3.1.4.RELEASE</spring.security.version>
     <metrics.version>2.1.1</metrics.version>
-    <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
+    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
     <rootProjectDir>..</rootProjectDir>
     <wro.version>1.7.7</wro.version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -858,7 +858,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="geonetwork/**" />
                       </fileset>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -830,6 +830,24 @@
             </executions>
           </plugin>
           <plugin>
+            <groupId>pl.project13.maven</groupId>
+            <artifactId>git-commit-id-plugin</artifactId>
+            <version>2.1.10</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>revision</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <prefix>git</prefix>
+              <failOnNoGitDirectory>false</failOnNoGitDirectory>
+              <skipPoms>false</skipPoms>
+              <verbose>false</verbose>
+            </configuration>
+          </plugin>
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
             <version>1.7</version>
@@ -868,6 +886,23 @@
                 </configuration>
                 <goals><goal>run</goal></goals>
               </execution>
+              <execution>
+                <id>set-project-packageversion</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <exportAntProperties>true</exportAntProperties>
+                  <target>
+                    <condition property="project.packageVersion"
+                      value="3.0.4.${maven.build.timestamp}~${git.commit.id.abbrev}"
+                      else="${project.version}.${maven.build.timestamp}~${git.commit.id.abbrev}">
+                      <matches string="${project.version}" pattern="SNAPSHOT$" />
+                    </condition>
+                  </target>
+               </configuration>
+            </execution>
             </executions>
           </plugin>
           <plugin>
@@ -878,7 +913,6 @@
               <packageName>georchestra-geonetwork3</packageName>
               <packageDescription>Debian package for the GeoNetwork fork of geOrchestra.</packageDescription>
               <packageVersion>${project.packageVersion}</packageVersion>
-              <packageRevision>${maven.build.timestamp}~${build.commit.id.abbrev}</packageRevision>
               <projectUrl>http://www.georchestra.org/</projectUrl>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>PSC</maintainerName>


### PR DESCRIPTION
in the 16.12 branch the git-commit-id-plugin wasnt used yet so add it.
As pom.xml sadly uses 3.0.4-SNAPSHOT for the geonetwork version, adapt
the antrun plugin config so that the final package is versionned like this:
geonetwork/web/target/georchestra-geonetwork3_3.0.4.201806271022~a732afe-1_all.deb

stop using packageRevision and remove extra dash from timestamp format

follows georchestra/georchestra#2092