### PR TITLE
Ensure etc/georchestra/.git is removed from the debian package (georc…

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -984,7 +984,7 @@
                 <configuration>
                   <target>
                     <delete includeemptydirs="true">
-                      <fileset dir="${project.build.directory}/deb/etc/georchestra">
+                      <fileset defaultexcludes="false" dir="${project.build.directory}/deb/etc/georchestra">
                         <include name="**/*" />
                         <exclude name="geonetwork/**" />
                       </fileset>


### PR DESCRIPTION
…hestra/georchestra#2094)

Disabling defaultexcludes in antrun delete target makes sure .git is removed in
the remove-useless-directories task.

Sorry, reusing the same branch.. cf #74 & #75 for the 17.12 & 16.12 branches.