### PR TITLE
Jetty - disable directory listing

### DIFF
--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -30,6 +30,12 @@
          metadata-complete="true">
 
   <display-name>geonetwork</display-name>
+
+  <context-param>
+    <param-name>org.eclipse.jetty.servlet.Default.dirAllowed</param-name>
+    <param-value>false</param-value>
+  </context-param>
+
   <listener>
     <listener-class>jeeves.config.springutil.JeevesContextLoaderListener</listener-class>
   </listener>


### PR DESCRIPTION
See https://github.com/georchestra/georchestra/issues/2088

Tests:
* compilation: web.xml OK
* runtime tested on a jetty & tomcat docker containers: the context-param under tomcat does not harm and is just ignored.