### PR TITLE
Formatter / hide view modes in full view when in angular mode

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -136,32 +136,36 @@
               </a>
             </section>
 
-            <section class="gn-md-side-viewmode">
-              <h4>
-                <i class="fa fa-fw fa-eye">&#160;</i>
-                <span><xsl:value-of select="$schemaStrings/viewMode"/></span>
-              </h4>
-              <xsl:for-each select="$configuration/editor/views/view[not(@disabled)]">
-                <ul>
-                  <li>
-                    <a>
-                      <xsl:attribute name="href">
-                        <xsl:choose>
-                          <xsl:when test="@name = 'xml'">
-                            <xsl:value-of select="concat($nodeUrl, 'api/records/', $metadataUuid, '/formatters/xml')"/>
-                          </xsl:when>
-                          <xsl:otherwise>
-                            <xsl:value-of select="concat($nodeUrl, 'api/records/', $metadataUuid, '/formatters/xsl-view?view=', @name, '&amp;portalLink=', $portalLink)"/>
-                          </xsl:otherwise>
-                        </xsl:choose>
-                      </xsl:attribute>
-                      <xsl:variable name="name" select="@name"/>
-                      <xsl:value-of select="$schemaStrings/*[name(.) = $name]"/>
-                    </a>
-                  </li>
-                </ul>
-              </xsl:for-each>
-            </section>
+            <!-- Display link to portal and other view only
+            when in pure HTML mode. -->
+            <xsl:if test="$root != 'div'">
+              <section class="gn-md-side-viewmode">
+                <h4>
+                  <i class="fa fa-fw fa-eye">&#160;</i>
+                  <span><xsl:value-of select="$schemaStrings/viewMode"/></span>
+                </h4>
+                <xsl:for-each select="$configuration/editor/views/view[not(@disabled)]">
+                  <ul>
+                    <li>
+                      <a>
+                        <xsl:attribute name="href">
+                          <xsl:choose>
+                            <xsl:when test="@name = 'xml'">
+                              <xsl:value-of select="concat($nodeUrl, 'api/records/', $metadataUuid, '/formatters/xml')"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                              <xsl:value-of select="concat($nodeUrl, 'api/records/', $metadataUuid, '/formatters/xsl-view?view=', @name, '&amp;portalLink=', $portalLink)"/>
+                            </xsl:otherwise>
+                          </xsl:choose>
+                        </xsl:attribute>
+                        <xsl:variable name="name" select="@name"/>
+                        <xsl:value-of select="$schemaStrings/*[name(.) = $name]"/>
+                      </a>
+                    </li>
+                  </ul>
+                </xsl:for-each>
+              </section>
+            </xsl:if>
 
             <section class="gn-md-side-access">
               <div class="well text-center">


### PR DESCRIPTION
Without this commit view modes are visible when viewing a record in full view:
![image](https://user-images.githubusercontent.com/10629150/46605777-eeb0d080-cafa-11e8-9d5c-caa5caa6f8a7.png)

Clicking the links breaks the layout.
