### PR TITLE
Demote ldap search messages to error level (#93)

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearch.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUserDetailsContextMapperWithProfileSearch.java
@@ -127,7 +127,7 @@ public class LDAPUserDetailsContextMapperWithProfileSearch extends
                             profileList.add(p);
                         }
                     } else {
-                        Log.error(Geonet.LDAP, "LDAP profile '" + profileName + "' does not match search pattern '"
+                        Log.debug(Geonet.LDAP, "LDAP profile '" + profileName + "' does not match search pattern '"
                             + privilegeQueryPattern + "'. Information ignored.");
                     }
                 }
@@ -194,7 +194,7 @@ public class LDAPUserDetailsContextMapperWithProfileSearch extends
                                 userDetails.addPrivilege(group,
                                     userDetails.getUser().getProfile());
                             } else {
-                                Log.error(Geonet.LDAP, "LDAP group '" + groupName
+                                Log.debug(Geonet.LDAP, "LDAP group '" + groupName
                                     + "' does not match search pattern '"
                                     + groupQueryPattern + "'. Information ignored.");
                             }
@@ -208,7 +208,7 @@ public class LDAPUserDetailsContextMapperWithProfileSearch extends
                             userDetails.addPrivilege(group,
                                 userDetails.getUser().getProfile());
                         } else {
-                            Log.error(Geonet.LDAP, "LDAP group '" + groupName
+                            Log.debug(Geonet.LDAP, "LDAP group '" + groupName
                                 + "' does not match search pattern '"
                                 + groupQueryPattern + "'. Information ignored.");
                         }


### PR DESCRIPTION
Those are triggered each time a user creates a new java session in
geonetwork, which can happen a lot with monitoring bypassing security-proxy.