### PR TITLE
Sets a default datadir as a java system property, only for jetty:run

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -805,6 +805,10 @@
               <name>org.eclipse.jetty.server.Request.maxFormContentSize</name>
               <value>5000000</value>
             </systemProperty>
+            <systemProperty>
+              <name>georchestra.datadir</name>
+              <value>/etc/georchestra</value>
+            </systemProperty>
           </systemProperties>
           <stopKey>JETTY_TOP</stopKey>
           <stopPort>8090</stopPort>


### PR DESCRIPTION
It allows to avoid to pass the -Dgeorchestra.datadir=/etc/georchestra
option to the mvn jetty:run command.

See georchestra/georchestra#2028 and georchestra/georchestra#2283.