### PR TITLE
In Jackson ObjectMapper, ignore unknown JSON fields in incoming requests

### DIFF
--- a/web/src/main/webResources/WEB-INF/spring-servlet.xml
+++ b/web/src/main/webResources/WEB-INF/spring-servlet.xml
@@ -91,6 +91,19 @@
     </property>
   </bean>
 
+  <bean class="org.fao.geonet.util.spring.HibernateAwareObjectMapper" id="hibernateAwareObjectMapper" />
+  <bean
+    class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+    <property name="targetObject" ref="hibernateAwareObjectMapper" />
+    <property name="targetMethod" value="configure" />
+    <property name="arguments">
+      <list>
+        <value type="com.fasterxml.jackson.databind.DeserializationFeature">FAIL_ON_UNKNOWN_PROPERTIES</value>
+        <value>false</value>
+      </list>
+    </property>
+  </bean>
+
   <mvc:annotation-driven content-negotiation-manager="cnManager">
     <mvc:message-converters>
       <bean class="org.fao.geonet.api.DOMElementMessageConverter"/>
@@ -106,7 +119,7 @@
 
       <bean class="org.springframework.http.converter.json.MappingJackson2HttpMessageConverter">
         <property name="objectMapper">
-          <bean class="org.fao.geonet.util.spring.HibernateAwareObjectMapper" />
+          <ref bean="hibernateAwareObjectMapper"/>
         </property>
       </bean>
     </mvc:message-converters>


### PR DESCRIPTION
In admin.console#/organization/groups, saving an existing group
generates the error:

> Could not read document: Unrecognized field \"langlabel\"   (class org.fao.geonet.domain.Group), not marked as ignorable (11 known   properties: \"enableAllowedCategories\", \"allowedCategories\", \"logo\",   \"name\", \"label\", \"website\", \"id\", \"description\", \"email\",   \"defaultCategory\", \"referrer\"])\n at [Source:   java.io.PushbackInputStream@66fce722; line: 1, column: 570] (through
  reference chain: org.fao.geonet.domain.Group[\"langlabel\"]); nested   exception is com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException:   Unrecognized field \"langlabel\" (class org.fao.geonet.domain.Group), not   marked as ignorable (11 known properties: \"enableAllowedCategories\",   \"allowedCategories\", \"logo\", \"name\", \"label\", \"website\", \"id\",   \"description\", \"email\", \"defaultCategory\", \"referrer\"])\n at   [Source: java.io.PushbackInputStream@66fce722; line: 1, column: 570]   (through reference chain: org.fao.geonet.domain.Group[\"langlabel\"])"

due to the `langlabel` field being present in the JSON sent to

  .../srv/api/groups/xxx

See https://github.com/geonetwork/core-geonetwork/commit/ef72fb47a430f80fcbd91348da3e1a705f914e66
and https://github.com/geonetwork/core-geonetwork/issues/2415.
