### PR TITLE
Adding a maven profile for jsonevent-layout

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -1113,7 +1113,16 @@
         </plugins>
       </build>
     </profile>
-
+    <profile>
+      <id>log4j-logstash</id>
+      <dependencies>
+        <dependency>
+          <groupId>net.logstash.log4j</groupId>
+          <artifactId>jsonevent-layout</artifactId>
+          <version>1.7</version>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <properties>


### PR DESCRIPTION
Already done in geOrchestra root pom but not propagated to GN (because no parent link b/w georchestra root pom and the GN one).

Untested, but should work if log4j1 is used (since both log4j1 and 2 are present in the classpath).

Does not modify anything unless the `log4j-logstash` profile is activated on the web/ module.
