### PR TITLE
Don't automatically add MimeFileType tag in resource name

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl
@@ -378,64 +378,6 @@
       </xsl:attribute>
     </xsl:copy>
   </xsl:template>
-  <!-- ================================================================= -->
-  <!-- online resources: download -->
-  <!-- ================================================================= -->
-
-  <xsl:template
-    match="gmd:CI_OnlineResource[matches(gmd:protocol/gco:CharacterString,'^WWW:DOWNLOAD-.*-http--download.*') and gmd:name]">
-    <xsl:variable name="fname" select="gmd:name/gco:CharacterString|gmd:name/gmx:MimeFileType"/>
-    <xsl:variable name="mimeType">
-      <xsl:call-template name="getMimeTypeFile">
-        <xsl:with-param name="datadir" select="/root/env/datadir"/>
-        <xsl:with-param name="fname" select="$fname"/>
-      </xsl:call-template>
-    </xsl:variable>
-
-    <xsl:copy>
-      <xsl:copy-of select="@*"/>
-      <gmd:linkage>
-        <gmd:URL>
-          <xsl:value-of select="gmd:linkage/gmd:URL"/>
-        </gmd:URL>
-      </gmd:linkage>
-      <xsl:copy-of select="gmd:protocol"/>
-      <xsl:copy-of select="gmd:applicationProfile"/>
-      <gmd:name>
-        <gmx:MimeFileType type="{$mimeType}">
-          <xsl:value-of select="$fname"/>
-        </gmx:MimeFileType>
-      </gmd:name>
-      <xsl:copy-of select="gmd:description"/>
-      <xsl:copy-of select="gmd:function"/>
-    </xsl:copy>
-  </xsl:template>
-
-  <!-- ================================================================= -->
-  <!-- Add mime type for downloadable online resources -->
-  <!-- ================================================================= -->
-
-  <xsl:template
-    match="gmd:CI_OnlineResource[starts-with(gmd:protocol/gco:CharacterString,'WWW:LINK-') and contains(gmd:protocol/gco:CharacterString,'http--download')]">
-    <xsl:variable name="mimeType">
-      <xsl:call-template name="getMimeTypeUrl">
-        <xsl:with-param name="linkage" select="gmd:linkage/gmd:URL"/>
-      </xsl:call-template>
-    </xsl:variable>
-
-    <xsl:copy>
-      <xsl:copy-of select="@*"/>
-      <xsl:copy-of select="gmd:linkage"/>
-      <xsl:copy-of select="gmd:protocol"/>
-      <xsl:copy-of select="gmd:applicationProfile"/>
-      <gmd:name>
-        <gmx:MimeFileType type="{$mimeType}"/>
-      </gmd:name>
-      <xsl:copy-of select="gmd:description"/>
-      <xsl:copy-of select="gmd:function"/>
-    </xsl:copy>
-  </xsl:template>
-
 
   <!-- ================================================================= -->
 


### PR DESCRIPTION
Anticipates changes brought by
 https://github.com/geonetwork/core-geonetwork/pull/3983
MimeFileType tag is causing interoperability issues, for instance when harvesting
from CKAN instance