### PR TITLE
Expand group name and label to 255 chars

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/Group.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Group.java
@@ -121,7 +121,7 @@ public class Group extends Localized implements Serializable {
      *
      * @return group name
      */
-    @Column(nullable = false, length = 32)
+    @Column(nullable = false, length = 255)
     public String getName() {
         return _name;
     }

--- a/domain/src/main/java/org/fao/geonet/domain/Localized.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Localized.java
@@ -48,7 +48,7 @@ import java.util.Map;
  * @ElementCollection(fetch = FetchType.LAZY, targetClass = String.class)
  * @CollectionTable(joinColumns = @JoinColumn(name = "iddes"), name = "groupsdes")
  * @MapKeyColumn(name = "langid", length = 5)
- * @Column(name = "label", nullable = false, length = 96)
+ * @Column(name = "label", nullable = false, length = 255)
  * public Map<String, String> getLabelTranslations() {
  * return super.getLabelTranslations();
  * }


### PR DESCRIPTION
Since LDAP organizations are synced into groups, group names and labels have to be bigger to cope with extra long organization names.