### PR TITLE
Fixed blocking error when opening directory editor

### DIFF
--- a/web/src/main/webapp/xslt/common/functions-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/functions-metadata.xsl
@@ -452,20 +452,25 @@
           for[@name = $name and @addDirective]/
           directiveAttributes/@*"/>
   </xsl:function>
-
+  
   <!-- Return if a flat mode exception has been defined in the current view for a field. -->
   <xsl:function name="gn-fn-metadata:isFieldFlatModeException" as="xs:boolean">
-    <xsl:param name="configuration" as="node()"/>
+    <xsl:param name="configuration" as="node()?"/>
     <xsl:param name="name" as="xs:string"/>
 
-    <xsl:variable name="exception"
-                  select="count($configuration/flatModeExceptions/for[@name = $name])"/>
+    <xsl:choose>
+      <xsl:when test="not($configuration)">
+        <xsl:value-of select="false()"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:variable name="exception"
+                      select="count($configuration/flatModeExceptions/for[@name = $name])"/>
 
-    <xsl:value-of
-      select="if ($exception > 0)
-      then true()
-      else false()"
-    />
+        <xsl:value-of select="if ($exception > 0)
+                      then true()
+                      else false()"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:function>
 
   <xsl:function name="gn-fn-metadata:getXPath" as="xs:string">


### PR DESCRIPTION
Make `metadata:isFieldFlatModeException` more robust in case the view does not have config (eg. directory view)

Backport of https://github.com/geonetwork/core-geonetwork/pull/4170

Tests: runtime OK
