### PR TITLE
Revert "LDAP / Preserve user privileges on sign in."

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/LDAPUtils.java
@@ -70,15 +70,8 @@ public class LDAPUtils {
         }
         User toSave = getUser(user, importPrivilegesFromLdap, userName);
 
-        // Add user groups if the user has no group assigned.
-        // This means that if some privileges has been assigned
-        // to the user after the creation, those are preserved.
-        // The default one from the LDAP config are only set
-        // it user has no privileges.
-        UserGroupRepository userGroupRepository = ApplicationContextHolder.get().getBean(UserGroupRepository.class);
-        List<UserGroup> existingGroups = userGroupRepository.findAll(UserGroupSpecs.hasUserId(user.getUser().getId()));
-
-        if (existingGroups.size() == 0 && user.getPrivileges().size() > 0) {
+        // Add user groups
+        if (user.getPrivileges().size() > 0) {
             entityManager.flush();
             entityManager.clear();
             List<UserGroup> ug = getPrivilegesAndCreateGroups(user,


### PR DESCRIPTION
This reverts commit 7461c029ba40af22c1902d46b144613a347a6ef9.

In geOrchestra, we actually want to trust the LDAP which is managed by the console webapp, and expect GeoNetwork to apply what is set (from the Console) in the LDAP, in regards to the users' group ownership and privileges. As a result, we want to get back to the previous behaviour.

Note: it leads the question of deactivating some GN services for managing users, as we consider that access and rights related topics should be managed from the console webapp only.
