### PR TITLE
jetty - disable server tokens

### DIFF
--- a/web/src/docker/Dockerfile
+++ b/web/src/docker/Dockerfile
@@ -29,6 +29,7 @@ CMD ["sh", "-c", "exec java \
 -Xms$XMS -Xmx$XMX \
 -XX:-UsePerfData \
 ${JAVA_OPTIONS} \
+-Djetty.httpConfig.sendServerVersion=false \
 -Djetty.jmxremote.rmiregistryhost=0.0.0.0 \
 -Djetty.jmxremote.rmiserverhost=0.0.0.0 \
 -jar /usr/local/jetty/start.jar"]


### PR DESCRIPTION
Do not disclose server version - a good practice