### PR TITLE
wfs harvesters - properly call quartzComponent.shutdown()

### DIFF
--- a/workers/camelPeriodicProducer/src/main/java/org/fao/geonet/camelPeriodicProducer/MessageProducerFactory.java
+++ b/workers/camelPeriodicProducer/src/main/java/org/fao/geonet/camelPeriodicProducer/MessageProducerFactory.java
@@ -27,9 +27,12 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.quartz2.QuartzComponent;
 import org.apache.camel.component.quartz2.QuartzEndpoint;
 import org.apache.camel.model.RouteDefinition;
+import org.fao.geonet.harvester.wfsfeatures.worker.WFSHarvesterRouteBuilder;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
 import org.quartz.TriggerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.annotation.PostConstruct;
@@ -41,7 +44,7 @@ public class MessageProducerFactory {
     protected RouteBuilder routeBuilder;
     @Autowired
     protected QuartzComponent quartzComponent;
-
+    private static Logger LOGGER = LoggerFactory.getLogger("geonetwork.harvest.wfs.camel");
     @PostConstruct
     public void init() throws Exception {
         quartzComponent.start();
@@ -73,6 +76,15 @@ public class MessageProducerFactory {
     public void destroy(Long id) throws Exception {
         routeBuilder.getContext().removeRouteDefinition(findRoute(id));
         routeBuilder.getContext().removeEndpoints("quartz2://" + id);
+
+    }
+
+    public void shutdown() {
+        try {
+            quartzComponent.shutdown();
+        } catch (Exception e) {
+            LOGGER.error("Error while trying to shutdown quartz", e);
+        }
     }
 
     private void writeRoute(MessageProducer messageProducer) throws Exception {

--- a/workers/camelPeriodicProducer/src/main/java/org/fao/geonet/camelPeriodicProducer/MessageProducerFactory.java
+++ b/workers/camelPeriodicProducer/src/main/java/org/fao/geonet/camelPeriodicProducer/MessageProducerFactory.java
@@ -27,7 +27,6 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.quartz2.QuartzComponent;
 import org.apache.camel.component.quartz2.QuartzEndpoint;
 import org.apache.camel.model.RouteDefinition;
-import org.fao.geonet.harvester.wfsfeatures.worker.WFSHarvesterRouteBuilder;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
 import org.quartz.TriggerBuilder;

--- a/workers/camelPeriodicProducer/src/main/resources/config-spring-geonetwork.xml
+++ b/workers/camelPeriodicProducer/src/main/resources/config-spring-geonetwork.xml
@@ -28,7 +28,7 @@
         http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-  <bean class="org.fao.geonet.camelPeriodicProducer.MessageProducerFactory"/>
+  <bean class="org.fao.geonet.camelPeriodicProducer.MessageProducerFactory" destroy-method="shutdown"/>
   <bean class="org.apache.camel.component.quartz2.QuartzComponent"/>
   <bean class="org.fao.geonet.camelPeriodicProducer.MessageProducerService"/>"
 


### PR DESCRIPTION
See: https://github.com/georchestra/georchestra/issues/3629

This allows the jmx mbeans to be unregistered, so a redeploy of the webapp won't clash with already existing ones.