### PR TITLE
docker - bootstrapping a default gn datadir in /mnt/geonetwork_datadir

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -1346,7 +1346,7 @@
       <properties>
         <dockerImageName>georchestra/${project.parent.artifactId}:${git.closest.tag.name}-dev</dockerImageName>
         <dockerDatadirScmUrl>scm:git:https://github.com/georchestra/datadir.git</dockerDatadirScmUrl>
-        <dockerDatadirScmVersion>docker-20.0</dockerDatadirScmVersion>
+        <dockerDatadirScmVersion>docker-master</dockerDatadirScmVersion>
         <dockerGnDatadirScmUrl>scm:git:https://github.com/georchestra/geonetwork_minimal_datadir.git</dockerGnDatadirScmUrl>
         <dockerGnDatadirScmVersion>gn4.0.6</dockerGnDatadirScmVersion>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -1347,6 +1347,9 @@
         <dockerImageName>georchestra/${project.parent.artifactId}:${git.closest.tag.name}-dev</dockerImageName>
         <dockerDatadirScmUrl>scm:git:https://github.com/georchestra/datadir.git</dockerDatadirScmUrl>
         <dockerDatadirScmVersion>docker-20.0</dockerDatadirScmVersion>
+        <dockerGnDatadirScmUrl>scm:git:https://github.com/georchestra/geonetwork_minimal_datadir.git</dockerGnDatadirScmUrl>
+        <dockerGnDatadirScmVersion>gn4.0.6</dockerGnDatadirScmVersion>
+
       </properties>
       <build>
         <finalName>geonetwork</finalName>
@@ -1355,13 +1358,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-scm-plugin</artifactId>
             <version>1.9.4</version>
-            <configuration>
-              <checkoutDirectory>${project.build.directory}/datadir/</checkoutDirectory>
-              <connectionUrl>${dockerDatadirScmUrl}</connectionUrl>
-              <pushChanges>false</pushChanges>
-              <scmVersion>${dockerDatadirScmVersion}</scmVersion>
-              <scmVersionType>branch</scmVersionType>
-            </configuration>
             <executions>
               <execution>
                 <id>checkout-docker-default-datadir</id>
@@ -1369,6 +1365,27 @@
                 <goals>
                   <goal>checkout</goal>
                 </goals>
+                <configuration>
+                  <checkoutDirectory>${project.build.directory}/datadir/</checkoutDirectory>
+                  <connectionUrl>${dockerDatadirScmUrl}</connectionUrl>
+                  <pushChanges>false</pushChanges>
+                  <scmVersion>${dockerDatadirScmVersion}</scmVersion>
+                  <scmVersionType>branch</scmVersionType>
+                </configuration>
+              </execution>
+              <execution>
+                <id>checkout-docker-gn-datadir</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>checkout</goal>
+                </goals>
+                <configuration>
+                  <checkoutDirectory>${project.build.directory}/gn_datadir/</checkoutDirectory>
+                  <connectionUrl>${dockerGnDatadirScmUrl}</connectionUrl>
+                  <pushChanges>false</pushChanges>
+                  <scmVersion>${dockerGnDatadirScmVersion}</scmVersion>
+                  <scmVersionType>branch</scmVersionType>
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -1389,6 +1406,12 @@
                   <targetPath>/etc/georchestra</targetPath>
                   <directory>${project.build.directory}/datadir</directory>
                   <include>${project.parent.artifactId}/**</include>
+                </resource>
+                <resource>
+                  <targetPath>/mnt/geonetwork_datadir</targetPath>
+                  <directory>${project.build.directory}/gn_datadir</directory>
+                  <exclude>.git**</exclude>
+                  <filtering>true</filtering>
                 </resource>
               </resources>
               <serverId>docker-hub</serverId>

--- a/web/src/docker/Dockerfile
+++ b/web/src/docker/Dockerfile
@@ -9,7 +9,7 @@ COPY --chown=jetty:jetty . /
 # Temporary switch to root
 USER root
 
-RUN mkdir /mnt/geonetwork_datadir && \
+RUN mkdir -p /mnt/geonetwork_datadir && \
     chown jetty:jetty /mnt/geonetwork_datadir
 
 # Restore jetty user


### PR DESCRIPTION
Tested without having to change the thesaurus URL in the datadir:
https://github.com/georchestra/datadir/blob/docker-master/datafeeder/frontend-config.json#L26

The DF is able to find keywords from the thesaurus with these defaults.

Note: I was not able to configure maven to exclude the `.git/ | .gitignore` from the `/mnt/geonetwork_datadir`, I think we can live with it.

Note2: Ansible is taking care of bootstrapping a default gn datadir quite the same way. It might be interesting to add the repository to the files installed by the debian package, but I don't feel like the `/mnt/` directory is meant for this, so I am a bit perplexed.
