### PR TITLE
Get header url and height from geOrchestra datadir

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -116,13 +116,11 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringReader;
+import java.io.*;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -269,6 +267,77 @@ public final class XslUtil {
     private static final char TS_WKT = ',';
     private static final char CS_WKT = ' ';
     private static ThreadLocal<Boolean> allowScripting = new InheritableThreadLocal<Boolean>();
+
+    private static String headerUrl;
+    private static String headerHeight;
+
+
+    public static String getGeorchestraHeaderUrl(){
+
+        if(XslUtil.headerUrl == null) {
+
+            // Set default value
+            XslUtil.headerUrl = "/header/";
+
+            // Load value from datadir
+            Properties properties = XslUtil.loadDatadirProperties();
+            if (properties.containsKey("headerUrl"))
+                XslUtil.headerUrl = properties.getProperty("headerUrl");
+        }
+
+        return XslUtil.headerUrl;
+    }
+
+    public static String getGeorchestraHeaderHeight(){
+
+        if(XslUtil.headerHeight == null) {
+
+            // Set default value
+            XslUtil.headerHeight = "90";
+
+            // Load value from datadir
+            Properties properties = XslUtil.loadDatadirProperties();
+            if (properties.containsKey("headerHeight"))
+                XslUtil.headerHeight = properties.getProperty("headerHeight");
+        }
+
+        return XslUtil.headerHeight;
+    }
+
+    private static Properties loadProperties(File path, Properties prop) throws IOException {
+        try(FileInputStream fisProp = new FileInputStream(path)) {
+            InputStreamReader isrProp = new InputStreamReader(fisProp, "UTF8");
+            prop.load(isrProp);
+        }
+        return prop;
+    }
+
+    private static Properties loadDatadirProperties(){
+
+        String globalDatadirPath = System.getProperty("georchestra.datadir");
+        Properties properties = new Properties();
+
+        if (globalDatadirPath != null) {
+            File defaultConfiguration = Paths.get(globalDatadirPath, "default.properties").toFile();
+            File geonetworkConfiguration = Paths.get(globalDatadirPath, "geonetwork", "geonetwork.properties").toFile();
+            if (defaultConfiguration.canRead()) {
+                try {
+                    XslUtil.loadProperties(defaultConfiguration, properties);
+                } catch (IOException e) {
+                    Log.error(Geonet.GEONETWORK, "Error getting the default geOrchestra configuration", e);
+                }
+            }
+            if (geonetworkConfiguration.canRead()) {
+                try {
+                    XslUtil.loadProperties(geonetworkConfiguration, properties);
+                } catch (IOException e) {
+                    Log.error(Geonet.GEONETWORK, "Error getting the geOrchestra/geonetwork configuration", e);
+                }
+            }
+        }
+        return properties;
+    }
+
 
     /**
      * clean the src of ' and <>

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -68,7 +68,7 @@
       and a facet search to get main site information.
       -->
       <body data-ng-controller="GnCatController" data-ng-class="[isHeaderFixed ? 'gn-header-fixed' : 'gn-header-relative', isLogoInHeader ? 'gn-logo-in-header' : 'gn-logo-in-navbar', isFooterEnabled ? 'gn-show-footer' : 'gn-hide-footer']">
-        <iframe src="/header/?active=geonetwork" style="width:100%;height:90px;border:none;overflow:hidden;" scrolling="no" frameborder="0"></iframe>
+        <iframe src="{$headerUrl}?active=geonetwork" style="width:100%;height:{$headerHeight}px;border:none;overflow:hidden;" scrolling="no" frameborder="0"></iframe>
 
         <div data-gn-alert-manager=""></div>
 

--- a/web/src/main/webapp/xslt/common/base-variables.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables.xsl
@@ -33,6 +33,9 @@
   <xsl:output name="default-indent-mode" indent="yes"
               omit-xml-declaration="yes"/>
 
+  <xsl:variable name="headerUrl" select="util:getGeorchestraHeaderUrl()"/>
+  <xsl:variable name="headerHeight" select="util:getGeorchestraHeaderHeight()"/>
+
   <!--
   -->
   <xsl:variable name="gnUri" select="'http://www.fao.org/geonetwork'"/>


### PR DESCRIPTION
It uses the:
* `headerUrl`
* `headerHeight`

properties from default.properties or geonetwork/geonetwork.properties from the geOrchestra datadir.

See https://github.com/georchestra/georchestra/issues/3667 for the motivation

Was 5ac74f5b9635e9014e414d1b1fc4a295b1458c47
which was previously b359ca89d855a5c31b3c7e92bccbd4eceff0e40f

Note: I rewrote the string formatting logic, and now use the java.nio paths calculation. I also removed the system.out.println() calls to go through the GN logger instead.

tests:
* Runtime tested on a geOrchestra which has a custom header url + a custom header height.
* testsuite ok when compiling (JDK11 in use so I also modified the dockerfile so that it uses jetty with a jre11, not 8). The modification has not been kept here because unrelated.