### PR TITLE
Ldap logo to gn

### DIFF
--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/AbstractGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/AbstractGroupSynchronizer.java
@@ -66,6 +66,8 @@ abstract class AbstractGroupSynchronizer implements GroupSynchronizer {
 
     protected @Autowired ExternalizedSecurityProperties configProperties;
 
+    private @Autowired LogoUpdater logoUpdater;
+
     protected AbstractGroupSynchronizer(CanonicalAccountsRepository canonicalAccounts) {
         Objects.requireNonNull(canonicalAccounts);
         this.canonicalAccounts = canonicalAccounts;
@@ -151,6 +153,7 @@ abstract class AbstractGroupSynchronizer implements GroupSynchronizer {
             updateLabelTranslations(canonical, group);
         }
 
+        logoUpdater.synchronize(canonical.getId(), group);
         group.setName(canonical.getName());
         group.setDescription(canonical.getDescription());
         group.setWebsite(canonical.getLinkage());

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/IntegrationConfiguration.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/IntegrationConfiguration.java
@@ -50,4 +50,9 @@ public class IntegrationConfiguration {
     protected @Bean OrgsBasedGroupSynchronizer orgsGroupSynchronizer() {
         return new OrgsBasedGroupSynchronizer(canonicalAccountsRepository);
     }
+
+    protected @Bean LogoUpdater logoUpdater() {
+        return new LogoUpdater(canonicalAccountsRepository);
+    }
+
 }

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/LogoUpdater.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/LogoUpdater.java
@@ -1,0 +1,61 @@
+package org.geonetwork.security.external.integration;
+
+import jeeves.server.context.ServiceContext;
+import jeeves.server.dispatchers.ServiceManager;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.resources.Resources;
+import org.geonetwork.security.external.repository.CanonicalAccountsRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import javax.annotation.PostConstruct;
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+
+public class LogoUpdater {
+
+    private CanonicalAccountsRepository canonicalAccounts;
+
+    private @Autowired
+    ConfigurableApplicationContext appContext;
+
+    private @Autowired
+    ServiceManager serviceManager;
+
+    private  @Autowired
+    Resources resources;
+
+    private Path directoryPath;
+    private ServiceContext serviceContext;
+
+
+    public LogoUpdater(CanonicalAccountsRepository canonicalAccounts) {
+        this.canonicalAccounts = canonicalAccounts;
+    }
+
+    @PostConstruct
+    public void init() {
+        directoryPath = resources.locateHarvesterLogosDirSMVC(appContext);
+        serviceContext = serviceManager.createServiceContext("synchronizing", appContext);
+        serviceContext.setLanguage("eng");
+    }
+
+    public void synchronize(String canonicalGroupId, Group group) {
+        try {
+            Optional<byte[]> optLogo = canonicalAccounts.getLogo(canonicalGroupId);
+            if (optLogo.isPresent()) {
+                Resources.ResourceHolder holder = resources.getWritableImage(serviceContext, canonicalGroupId, directoryPath);
+                Files.copy(new ByteArrayInputStream(optLogo.get()), holder.getPath(), StandardCopyOption.REPLACE_EXISTING);
+                group.setLogo(canonicalGroupId);
+            } else {
+                resources.deleteImageIfExists(canonicalGroupId, directoryPath);
+                group.setLogo(null);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/repository/CanonicalAccountsRepository.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/repository/CanonicalAccountsRepository.java
@@ -66,4 +66,6 @@ public interface CanonicalAccountsRepository {
      * Note whereas an Role name may change over time, it's required to be unique.
      */
     Optional<CanonicalGroup> findRoleByName(String name);
+
+    Optional<byte[]> getLogo(String id);
 }

--- a/georchestra-integration/georchestra-authnz/src/main/java/org/georchestra/geonetwork/security/integration/GeorchestraAccountsRepository.java
+++ b/georchestra-integration/georchestra-authnz/src/main/java/org/georchestra/geonetwork/security/integration/GeorchestraAccountsRepository.java
@@ -74,4 +74,7 @@ public class GeorchestraAccountsRepository implements CanonicalAccountsRepositor
         return georchestraRoles.findAll().stream().map(mapper::toCanonical).collect(Collectors.toList());
     }
 
+    public @Override Optional<byte[]> getLogo(String id) {
+        return georchestraOrgs.getLogo(id);
+    }
 }

--- a/georchestra-integration/georchestra-authnz/src/test/resources/org/georchestra/geonetwork/security/integration/defaultOrganizations.json
+++ b/georchestra-integration/georchestra-authnz/src/test/resources/org/georchestra/geonetwork/security/integration/defaultOrganizations.json
@@ -8,7 +8,7 @@
 		"category": "Association",
 		"description": "Association PSC geOrchestra",
 		"notes": "Internal CRM notes on PSC",
-		"lastUpdated": "2200a6051fcef499884e1cfa8b6625766e76df75d18ce2316c23b421db99e147",
+		"lastUpdated": "b9142a69098fecfb1b639d6a8e9ac091284a23f6cc103dc3f5ca71688e42d9c3",
 		"members": [
 			"testadmin",
 			"testuser"

--- a/web/src/main/filters/prod.properties
+++ b/web/src/main/filters/prod.properties
@@ -41,7 +41,7 @@ ignoreFailingProcessor=true
 xsl_TransformerFactoryImpl=de.fzi.dbs.xml.transform.CachingTransformerFactory
 
 # goes in web.xml session-timeout tag.  It is in minutes
-sessionTimeout=35
+sessionTimeout=1440
 
 # set to true to have cookies flagged as Secure in production (requires HTTPS)
 cookieSecureFlag=false


### PR DESCRIPTION
if org lastupdated hash let think that an org logo could have been updated, change it at gn side.

exception thrown if file copy trouble for example can bring desynchronisation,  gn db wtritten hash and the one computed from ldap will be the same, but the logo writing has failed: alternative could have been forbid synchronisation in such a figure, i.e. let ldap deleted users continue to live in gn db (throwing exception to rollback transaction could have kill the whole sync process).

point is that by now one can query ldap for logo from org canonical uuid and don't need anymore to get it from gn, (even if it is available).

there was no time left to automate tests at gn side.

linked with https://github.com/georchestra/georchestra/pull/3853.

![logos_from_ldap](https://user-images.githubusercontent.com/18677090/205467838-502ffa4d-e2dd-4afe-aa5d-72af12baa4fc.png)

