### PR TITLE
Allow overriding jdbc.host and port by PG_HOST and PG_PORT env. vars

### DIFF
--- a/web/src/docker/docker-entrypoint.d/01-wait-for-db
+++ b/web/src/docker/docker-entrypoint.d/01-wait-for-db
@@ -1,16 +1,24 @@
 #!/bin/bash
 set -e
 
-HOST=`grep jdbc.host                               \
-  /etc/georchestra/geonetwork/geonetwork.properties \
-  | cut -d '=' -f 2                                 \
-  | xargs`
+if [[ -n $PG_HOST ]]; then
+  HOST=$PG_HOST
+else
+  HOST=`grep jdbc.host                               \
+    /etc/georchestra/geonetwork/geonetwork.properties \
+    | cut -d '=' -f 2                                 \
+    | xargs`
+fi
 
-PORT=`grep jdbc.port                                \
-  /etc/georchestra/geonetwork/geonetwork.properties \
-  | cut -d '=' -f 2                                 \
-  | xargs`
-PORT="${PORT:-5432}"
+if [[ -n $PG_PORT ]]; then
+  PORT=$PG_PORT
+else
+  PORT=`grep jdbc.port                                \
+    /etc/georchestra/geonetwork/geonetwork.properties \
+    | cut -d '=' -f 2                                 \
+    | xargs`
+  PORT="${PORT:-5432}"
+fi
 
 echo Waiting for $HOST:$PORT to become available...
 /wait-for-it.sh $HOST:$PORT -s -t 0 -- echo "DB OK"

--- a/web/src/docker/docker-entrypoint.d/01-wait-for-db
+++ b/web/src/docker/docker-entrypoint.d/01-wait-for-db
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-if [[ -n $PG_HOST ]]; then
-  HOST=$PG_HOST
+if [[ -n $PGHOST ]]; then
+  HOST=$PGHOST
 else
   HOST=`grep jdbc.host                               \
     /etc/georchestra/geonetwork/geonetwork.properties \
@@ -10,8 +10,8 @@ else
     | xargs`
 fi
 
-if [[ -n $PG_PORT ]]; then
-  PORT=$PG_PORT
+if [[ -n $PGPORT ]]; then
+  PORT=$PGPORT
 else
   PORT=`grep jdbc.port                                \
     /etc/georchestra/geonetwork/geonetwork.properties \


### PR DESCRIPTION
In wait-for-db script, if using an environment variable in the datadir config, the variable is not expanded, which causes the script to hang and prevent Geonetwork from starting. This allows to use environment variables and actually bypass the datadir config for ths script