### PR TITLE
[feat] allow to open 3dtiles links in mapstore #226

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/labels.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/labels.xml
@@ -3924,6 +3924,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web
       </option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/labels.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/labels.xml
@@ -6325,6 +6325,7 @@ la non-évaluation</b>, dans le cadre de métadonnées INSPIRE
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ara/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ara/labels.xml
@@ -2192,6 +2192,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option show="-" value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/cat/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/cat/labels.xml
@@ -1874,6 +1874,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option value="OGC:CSW">OGC-CSW Servei de catàleg per a la Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Llenguatge de Marcat Geogràfic</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/chi/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/chi/labels.xml
@@ -2188,6 +2188,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option show="-" value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/dut/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/dut/labels.xml
@@ -1836,6 +1836,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option show="-" value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
@@ -2273,6 +2273,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fin/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fin/labels.xml
@@ -2157,6 +2157,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web
       </option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fre/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fre/labels.xml
@@ -4356,6 +4356,7 @@ la non-évaluation</b>, dans le cadre de métadonnées INSPIRE
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
@@ -2584,6 +2584,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option value="OGC:WMS-http-get-map">OGC-WMS Web Map Service</option>
       <option value="OGC:WFS-http-get-capabilities">OGC-WFS Web Feature Service</option>
       <option value="OGC:WCS-http-get-capabilities">OGC-WCS Web Coverage Service</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ita/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ita/labels.xml
@@ -2040,6 +2040,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web
       </option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/nor/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/nor/labels.xml
@@ -1972,6 +1972,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option show="-" value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/pol/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/pol/labels.xml
@@ -1644,6 +1644,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/labels.xml
@@ -2128,6 +2128,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option show="-" value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/rus/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/rus/labels.xml
@@ -2222,6 +2222,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option show="-" value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/slo/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/slo/labels.xml
@@ -1753,6 +1753,7 @@ presnosť / vertikálna -</option>
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/spa/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/spa/labels.xml
@@ -1944,6 +1944,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option value="OGC:CSW">OGC-CSW Servicio de catálogo para la Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Lenguaje de Marcado Geográfico</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/tur/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/tur/labels.xml
@@ -1784,6 +1784,7 @@
       <option value="OGC API - Features">OGC API - Features</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -126,6 +126,8 @@
 
       var addWMSToMap =
         gnViewerSettings.resultviewFns && gnViewerSettings.resultviewFns.addMdLayerToMap;
+      var add3dTilesToMap =
+        gnViewerSettings.resultviewFns && gnViewerSettings.resultviewFns.addMdLayerToMap;
       var addEsriRestToMap =
         gnViewerSettings.resultviewFns && gnViewerSettings.resultviewFns.addMdLayerToMap;
 
@@ -278,6 +280,11 @@
           iconClass: "fa-globe",
           label: "addToMap",
           action: addWMTSToMap
+        },
+        3DTILES: {
+          iconClass: "fa-globe",
+          label: "addToMap",
+          action: add3dTilesToMap
         },
         TMS: {
           iconClass: "fa-globe",
@@ -506,6 +513,8 @@
             return "ESRI:REST";
           } else if (protocolOrType.match(/wmts/i)) {
             return "WMTS";
+          } else if (protocolOrType.match(/3dtiles/i)) {
+            return "3DTILES";
           } else if (protocolOrType.match(/tms/i)) {
             return "TMS";
           } else if (protocolOrType.match(/wfs/i)) {

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -281,7 +281,7 @@
           label: "addToMap",
           action: addWMTSToMap
         },
-        3DTILES: {
+        "3DTILES": {
           iconClass: "fa-globe",
           label: "addToMap",
           action: add3dTilesToMap

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -79,7 +79,7 @@
           return r.mimeType;
         } else if (r.protocol && r.protocol.indexOf("WWW:DOWNLOAD:") >= 0) {
           return r.protocol.replace("WWW:DOWNLOAD:", "");
-        } else if (mainType.match(/W([MCF]|MT)S.*|ESRI:REST/) != null) {
+        } else if (mainType.match(/W([MCF]|MT)S.*|3DTILES|ESRI:REST/) != null) {
           return mainType.replace("SERVICE", "");
         } else if (mainType.match(/KML|GPX/) != null) {
           return mainType;

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1276,6 +1276,7 @@
           gnSearchSettings.mapProtocols = {
             layers: [
               "OGC:WMS",
+              "OGC:3DTILES",
               "OGC:WMTS",
               "OGC:WMS-1.1.1-http-get-map",
               "OGC:WMS-1.3.0-http-get-map",

--- a/web-ui/src/main/resources/catalog/style/gn_icons.less
+++ b/web-ui/src/main/resources/catalog/style/gn_icons.less
@@ -274,6 +274,7 @@
 .gn-icontype-wps,
 .gn-icontype-wcs,
 .gn-icontype-atom,
+.gn-icontype-3dtiles,
 .gn-icontype-esri-rest,
 .gn-icontype-wfs {
   background-color: @btn-success-bg !important;

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -356,6 +356,8 @@
               ? "wmts"
               : link.protocol == "ESRI:REST" || link.protocol.startsWith("ESRI REST")
               ? "esrirest"
+              : link.protocol == "OGC:3DTILES"
+              ? "3dtiles"
               : "wms",
           url: $filter("gnLocalized")(link.url) || link.url
         };

--- a/web-ui/src/main/resources/catalog/views/georchestra/module.js
+++ b/web-ui/src/main/resources/catalog/views/georchestra/module.js
@@ -42,7 +42,7 @@
       gnSearchSettings.linkTypes = {
         links: ["LINK"],
         downloads: ["DOWNLOAD"],
-        layers: ["OGC:WMS"],
+        layers: ["OGC:WMS", "OGC:3DTILES"],
         maps: ["ows"]
       };
 


### PR DESCRIPTION
Open questions:
- i'm not sure if ff75e175cd29786ee70c371782f01106dc3417a1 is required, when i doubt i added it.
- still need testing at runtime, my own dev instance is still on 4.0.6 where i've tested a similar working diff

a metadata with:
```
<gmd:CI_OnlineResource>
  <gmd:linkage>
    <gmd:URL>
      https://3d.craig.fr/datasets/Domerat_bati3d/3dtiles/tileset.json
    </gmd:URL>
  </gmd:linkage>
  <gmd:protocol>
    <gco:CharacterString>OGC:3DTILES</gco:CharacterString>
  </gmd:protocol>
  <gmd:name>
    <gco:CharacterString>3dtiles domérat</gco:CharacterString>
  </gmd:name>
</gmd:CI_OnlineResource>
```
should open a configured mapstore, sending it `[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["3dtiles domérat"],"sources":[{"type":"3dtiles","url":"https%3A%2F2F3d.craig.fr%2Fdatasets%2FDomerat_bati3d%2F3dtiles%2Ftileset.json"}]}]` in the actions query param. Relies on a mapstore instance having geosolutions-it/MapStore2#8055 (yeah i know, recent)

Will close #226