### PR TITLE
geor - customizations - avoid defining multiple geonetwork datadir beans

### DIFF
--- a/georchestra-integration/externalized-accounts/src/main/resources/config-spring-geonetwork.xml
+++ b/georchestra-integration/externalized-accounts/src/main/resources/config-spring-geonetwork.xml
@@ -14,6 +14,5 @@
 
   <bean id="ServiceManager" class="jeeves.server.dispatchers.ServiceManager" lazy-init="true"/>
   <bean id="resources" class="org.fao.geonet.resources.FileResources"/>
-  <bean id="GeonetworkDataDirectory" class="org.fao.geonet.kernel.GeonetworkDataDirectory" lazy-init="true"/>
 
 </beans>

--- a/georchestra-integration/externalized-accounts/src/test/resources/config-spring-geonetwork.xml
+++ b/georchestra-integration/externalized-accounts/src/test/resources/config-spring-geonetwork.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans default-lazy-init="true" xmlns="http://www.springframework.org/schema/beans"
-  xmlns:ctx="http://www.springframework.org/schema/context"
+<beans default-lazy-init="true"
+  xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ctx="http://www.springframework.org/schema/context"
   xsi:schemaLocation="
   http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
   http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
@@ -9,8 +10,10 @@
 
   <ctx:annotation-config />
   <!-- scan only the @Configuration class and let it do its job -->
-  <ctx:component-scan base-package="org.georchestra.geonetwork.security.integration"/>
+  <ctx:component-scan base-package="org.geonetwork.security.external.configuration" />
 
   <bean id="ServiceManager" class="jeeves.server.dispatchers.ServiceManager" lazy-init="true"/>
   <bean id="resources" class="org.fao.geonet.resources.FileResources"/>
+  <bean id="GeonetworkDataDirectory" class="org.fao.geonet.kernel.GeonetworkDataDirectory" lazy-init="true"/>
+
 </beans>

--- a/georchestra-integration/georchestra-authnz/src/test/resources/config-spring-geonetwork.xml
+++ b/georchestra-integration/georchestra-authnz/src/test/resources/config-spring-geonetwork.xml
@@ -13,4 +13,6 @@
 
   <bean id="ServiceManager" class="jeeves.server.dispatchers.ServiceManager" lazy-init="true"/>
   <bean id="resources" class="org.fao.geonet.resources.FileResources"/>
+  <bean id="GeonetworkDataDirectory" class="org.fao.geonet.kernel.GeonetworkDataDirectory" lazy-init="true"/>
+
 </beans>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -1412,7 +1412,7 @@
         <dockerDatadirScmUrl>scm:git:https://github.com/georchestra/datadir.git</dockerDatadirScmUrl>
         <dockerDatadirScmVersion>docker-master</dockerDatadirScmVersion>
         <dockerGnDatadirScmUrl>scm:git:https://github.com/georchestra/geonetwork_minimal_datadir.git</dockerGnDatadirScmUrl>
-        <dockerGnDatadirScmVersion>gn4.0.6</dockerGnDatadirScmVersion>
+        <dockerGnDatadirScmVersion>gn4.2.2</dockerGnDatadirScmVersion>
 
       </properties>
       <build>


### PR DESCRIPTION
See https://github.com/georchestra/georchestra/issues/3918

I wonder if this is the right approach, as we duplicate the resources, but it could make sense to have an environment which wil diverge a bit from the "production" one only for testing purposes.

tests:
* `mvn verify` on the georchestra-integration OK
* runtime tested by modifying affected jars directly into a running docker container.