### PR TITLE
ODS: Fix mapping of ods metadata and ressource dates

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
@@ -143,6 +143,16 @@
               <gco:DateTime><xsl:value-of select="metas/modified"/></gco:DateTime>
             </cit:date>
             <cit:dateType>
+              <cit:CI_DateTypeCode codeList="codeListLocation#CI_DateTypeCode" codeListValue="publication"/>
+            </cit:dateType>
+          </cit:CI_Date>
+        </mdb:dateInfo>
+        <mdb:dateInfo>
+          <cit:CI_Date>
+            <cit:date>
+              <gco:DateTime><xsl:value-of select="metas/metadata_processed"/></gco:DateTime>
+            </cit:date>
+            <cit:dateType>
               <cit:CI_DateTypeCode codeList="codeListLocation#CI_DateTypeCode" codeListValue="revision"/>
             </cit:dateType>
           </cit:CI_Date>
@@ -177,10 +187,20 @@
                 <cit:date>
                   <cit:CI_Date>
                     <cit:date>
-                      <gco:DateTime/>
+                      <gco:DateTime><xsl:value-of select="metas/modified"/></gco:DateTime>
                     </cit:date>
                     <cit:dateType>
-                      <cit:CI_DateTypeCode codeList="codeListLocation#CI_DateTypeCode" codeListValue="creation"/>
+                      <cit:CI_DateTypeCode codeList="codeListLocation#CI_DateTypeCode" codeListValue="publication"/>
+                    </cit:dateType>
+                  </cit:CI_Date>
+                </cit:date>
+                <cit:date>
+                  <cit:CI_Date>
+                    <cit:date>
+                      <gco:DateTime><xsl:value-of select="metas/data_processed"/></gco:DateTime>
+                    </cit:date>
+                    <cit:dateType>
+                      <cit:CI_DateTypeCode codeList="codeListLocation#CI_DateTypeCode" codeListValue="revision"/>
                     </cit:dateType>
                   </cit:CI_Date>
                 </cit:date>


### PR DESCRIPTION
PR fixes the mapping of ODS date attributes `modified`, `metadata_processed`, `data_processed` according to the following conditions:

metadata:
creation = considered "modified" (md is created when ressource is loaded) 
revision =  "metadata processed"
publication = "modified"

ressource:
creation = not avavailable in ods
revision = "data processed"
publication = "modified"

Note: Has only been tested on core-geonetwork 4.2.2. The following [accroche_velos_.zip](https://github.com/georchestra/geonetwork/files/11115450/accroche_velos_.zip) includes a harvested record in XML, before and after the change.

Sidenote: Harvesting an ODS [catalog](https://opendata.lillemetropole.fr/api/datasets/1.0/search?refine.datasetid=accroche_velos&start=0&rows=300) we want to use this fix on did not seem to work with current main branch of upstream 
