### PR TITLE
DKAN: Fix date conversion to accept "DD-MM-YYYY HH:MM" format

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonDkan.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonDkan.xsl
@@ -367,7 +367,7 @@
 
     <!-- Regexps for parsing expected date formats -->
     <!-- examples of localized date: "jeu, 24/12/2020 - 03:00", "24-12-2020 03:00" -->
-    <xsl:variable name="regExLoc">^.*([0-9]{2})[-/]([0-9]{2})[-/]([0-9]{4})\s+([0-9]{2}:[0-9]{2})$</xsl:variable>
+    <xsl:variable name="regExLoc">^.*([0-9]{2})[-/]([0-9]{2})[-/]([0-9]{4})[-\s]+([0-9]{2}:[0-9]{2}).*$</xsl:variable>
     <!-- example of internationalized date: "2020-12-24 03:00:00" -->
     <xsl:variable name="regExInt">^([0-9]{4})-([0-9]{2})-([0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2})$</xsl:variable>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonDkan.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonDkan.xsl
@@ -366,9 +366,9 @@
     <xsl:param name="value"></xsl:param>
 
     <!-- Regexps for parsing expected date formats -->
-    <!-- example of localized date: "jeu, 03/06/2021 - 03:00" -->
-    <xsl:variable name="regExLoc">^.*([0-9]{2})/([0-9]{2})/([0-9]{4}) - ([0-9]{2}:[0-9]{2})$</xsl:variable>
-    <!-- example of internationalized date: "2020-12-09 00:00:00" -->
+    <!-- examples of localized date: "jeu, 24/12/2020 - 03:00", "24-12-2020 03:00" -->
+    <xsl:variable name="regExLoc">^.*([0-9]{2})[-/]([0-9]{2})[-/]([0-9]{4})\s+([0-9]{2}:[0-9]{2})$</xsl:variable>
+    <!-- example of internationalized date: "2020-12-24 03:00:00" -->
     <xsl:variable name="regExInt">^([0-9]{4})-([0-9]{2})-([0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2})$</xsl:variable>
 
     <xsl:variable name="dateFormatted">


### PR DESCRIPTION
PR makes `regExLoc` for localized date conversion more permissive. Now accepts `-` and `/` as date separators and just whitespace chars between date and time. This allows date formats such as `31-03-2023 00:15` in addition to the current "jeu, `24/12/2020 - 03:00`.

IMO, it makes sense to make the existing regexp more permissive, as this will also allow similar formats like 
- `jeu, 24/12/2020 03:00`
- `24/12/2020 03:00`
- `24-12-2020 - 03:00`

A more restrictive alternative would be to add a separate regexp and matching condition :

    <!-- example of custom date: "24-12-2020 00:00" -->
    <xsl:variable name="regExCustom">^([0-9]{2})-([0-9]{2})-([0-9]{4}) ([0-9]{2}:[0-9]{2})$</xsl:variable>
    
    <xsl:when test="matches($value, $regExCustom)">
      <xsl:value-of select="replace($value, $regExCustom, '$3-$2-$1T$4:00')"></xsl:value-of>
    </xsl:when>