### PR TITLE
ui - provide a default configuration suitable for geOrchestra

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -766,5 +766,632 @@ INSERT INTO GUF_RatingCriteria (id, name, isinternal) VALUES (4, 'ServiceQuality
 -- === Table: Settings_ui
 -- ======================================================================
 
-INSERT INTO settings_ui (id, configuration) VALUES ('srv','{"langDetector":{"fromHtmlTag":false,"regexp":"^(?:/.+)?/.+/([a-z]{2,3})/.+","default":"eng"},"nodeDetector":{"regexp":"^(?:/.+)?/(.+)/[a-z]{2,3}/.+","default":"srv"},"serviceDetector":{"regexp":"^(?:/.+)?/.+/[a-z]{2,3}/(.+)","default":"catalog.search"},"baseURLDetector":{"regexp":"^((?:/.+)?)+/.+/[a-z]{2,3}/.+","default":"/geonetwork"},"mods":{"global":{"humanizeDates":true,"dateFormat":"DD-MM-YYYY HH:mm","timezone":"Browser"},"footer":{"enabled":true,"showSocialBarInFooter":true},"header":{"enabled":true,"languages":{"eng":"en","dut":"nl","fre":"fr","ger":"de","kor":"ko","spa":"es","cze":"cs","cat":"ca","fin":"fi","ice":"is","ita":"it","por":"pt","rus":"ru","chi":"zh","slo":"sk","swe":"sv"},"isLogoInHeader":false,"logoInHeaderPosition":"left","fluidHeaderLayout":true,"showGNName":true,"isHeaderFixed":false},"cookieWarning":{"enabled":false,"cookieWarningMoreInfoLink":"","cookieWarningRejectLink":""},"home":{"enabled":true,"appUrl":"../../{{node}}/{{lang}}/catalog.search#/home","showSocialBarInFooter":false,"fluidLayout":true,"facetConfig":{"inspireThemeUri":{"terms":{"field":"inspireThemeUri","size":34}},"cl_topic.key":{"terms":{"field":"cl_topic.key","size":20}},"cl_hierarchyLevel.key":{"terms":{"field":"cl_hierarchyLevel.key","size":10}}}},"search":{"enabled":true,"appUrl":"../../{{node}}/{{lang}}/catalog.search#/search","hitsperpageValues":[30,60,120],"paginationInfo":{"hitsPerPage":30},"queryBase":"any:(${any}) resourceTitleObject.default:(${any})^2","exactMatchToggle":true,"scoreConfig":{"boost":"5","functions":[{"filter":{"exists":{"field":"parentUuid"}},"weight":0.3},{"filter":{"match":{"cl_status.key":"obsolete"}},"weight":0.3},{"gauss":{"dateStamp":{"scale":"365d","offset":"90d","decay":0.5}}}],"score_mode":"multiply"},"autocompleteConfig":{"query":{"bool":{"must":[{"multi_match":{"query":"","type":"bool_prefix","fields":["resourceTitleObject.*","resourceAbstractObject.*","tag","resourceIdentifier"]}}]}},"_source":["resourceTitleObject"],"from":0,"size":20},"moreLikeThisConfig":{"more_like_this":{"fields":["resourceTitleObject.default","resourceAbstractObject.default","tag.raw"],"like":null,"min_term_freq":1,"max_query_terms":12}},"facetTabField":"","isVegaEnabled":true,"facetConfig":{"cl_hierarchyLevel.key":{"terms":{"field":"cl_hierarchyLevel.key"},"aggs":{"format":{"terms":{"field":"format"}}}},"cl_spatialRepresentationType.key":{"terms":{"field":"cl_spatialRepresentationType.key","size":10}},"availableInServices":{"filters":{"filters":{"availableInViewService":{"query_string":{"query":"+linkProtocol:/OGC:WMS.*/"}},"availableInDownloadService":{"query_string":{"query":"+linkProtocol:/OGC:WFS.*/"}}}}},"th_gemet_tree.default":{"terms":{"field":"th_gemet_tree.default","size":100,"order":{"_key":"asc"},"include":"[^^]+^?[^^]+"}},"th_httpinspireeceuropaeumetadatacodelistPriorityDataset-PriorityDataset_tree.default":{"terms":{"field":"th_httpinspireeceuropaeumetadatacodelistPriorityDataset-PriorityDataset_tree.default","size":100,"order":{"_key":"asc"}}},"tag.default":{"terms":{"field":"tag.default","include":".*","size":10},"meta":{"caseInsensitiveInclude":true}},"th_regions_tree.default":{"terms":{"field":"th_regions_tree.default","size":100,"order":{"_key":"asc"}}},"resolutionScaleDenominator":{"histogram":{"field":"resolutionScaleDenominator","interval":10000,"keyed":true,"min_doc_count":1},"meta":{"collapsed":true}},"creationYearForResource":{"histogram":{"field":"creationYearForResource","interval":5,"keyed":true,"min_doc_count":1},"meta":{"collapsed":true}},"OrgForResource":{"terms":{"field":"OrgForResource","include":".*","size":15},"meta":{"caseInsensitiveInclude":true}},"cl_maintenanceAndUpdateFrequency.key":{"terms":{"field":"cl_maintenanceAndUpdateFrequency.key","size":10},"meta":{"collapsed":true}}},"filters":null,"sortbyValues":[{"sortBy":"relevance","sortOrder":""},{"sortBy":"dateStamp","sortOrder":"desc"},{"sortBy":"createDate","sortOrder":"desc"},{"sortBy":"resourceTitleObject.default.keyword","sortOrder":""},{"sortBy":"rating","sortOrder":"desc"},{"sortBy":"popularity","sortOrder":"desc"}],"sortBy":"relevance","resultViewTpls":[{"tplUrl":"../../catalog/components/search/resultsview/partials/viewtemplates/grid.html","tooltip":"Grid","icon":"fa-th"},{"tplUrl":"../../catalog/components/search/resultsview/partials/viewtemplates/list.html","tooltip":"List","icon":"fa-bars"}],"resultTemplate":"../../catalog/components/search/resultsview/partials/viewtemplates/grid.html","formatter":{"list":[{"label":"defaultView","url":""},{"label":"full","url":"/formatters/xsl-view?root=div&view=advanced"}],"defaultUrl":""},"downloadFormatter":[{"label":"exportMEF","url":"/formatters/zip?withRelated=false","class":"fa-file-zip-o"},{"label":"exportPDF","url":"/formatters/xsl-view?output=pdf&language=${lang}","class":"fa-file-pdf-o"},{"label":"exportXML","url":"/formatters/xml","class":"fa-file-code-o"}],"grid":{"related":["parent","children","services","datasets"]},"linkTypes":{"links":["LINK","kml"],"downloads":["DOWNLOAD"],"layers":["OGC","ESRI:REST"],"maps":["ows"]},"isFilterTagsDisplayedInSearch":true,"usersearches":{"enabled":false,"includePortals":true,"displayFeaturedSearchesPanel":false},"savedSelection":{"enabled":false}},"map":{"enabled":false,"appUrl":"../../{{node}}/{{lang}}/catalog.search#/map","externalViewer":{"enabled":false,"enabledViewAction":false,"baseUrl":"http://www.example.com/viewer","urlTemplate":"http://www.example.com/viewer?url=${service.url}&type=${service.type}&layer=${service.title}&lang=${iso2lang}&title=${md.defaultTitle}","openNewWindow":false,"valuesSeparator":","},"is3DModeAllowed":false,"isSaveMapInCatalogAllowed":true,"isExportMapAsImageEnabled":false,"storage":"sessionStorage","bingKey":"","listOfServices":{"wms":[],"wmts":[]},"projection":"EPSG:3857","projectionList":[{"code":"urn:ogc:def:crs:EPSG:6.6:4326","label":"WGS84 (EPSG:4326)"},{"code":"EPSG:3857","label":"Google mercator (EPSG:3857)"}],"switcherProjectionList":[{"code":"EPSG:3857","label":"Google mercator (EPSG:3857)"}],"disabledTools":{"processes":false,"addLayers":false,"projectionSwitcher":false,"layers":false,"legend":false,"filter":false,"contexts":false,"print":false,"mInteraction":false,"graticule":false,"mousePosition":true,"syncAllLayers":false,"drawVector":false},"graticuleOgcService":{},"map-viewer":{"context":"../../map/config-viewer.xml","extent":[0,0,0,0],"layers":[]},"map-search":{"context":"../../map/config-viewer.xml","extent":[0,0,0,0],"layers":[]},"map-editor":{"context":"","extent":[0,0,0,0],"layers":[{"type":"osm"}]},"autoFitOnLayer":false},"geocoder":{"enabled":true,"appUrl":"https://secure.geonames.org/searchJSON"},"recordview":{"enabled":true,"isSocialbarEnabled":true},"editor":{"enabled":true,"appUrl":"../../{{node}}/{{lang}}/catalog.edit","isUserRecordsOnly":false,"minUserProfileToCreateTemplate":"","isFilterTagsDisplayed":false,"fluidEditorLayout":true,"createPageTpl":"../../catalog/templates/editor/new-metadata-horizontal.html","editorIndentType":"","allowRemoteRecordLink":true,"facetConfig":{"resourceType":{"terms":{"field":"resourceType","size":20}},"cl_status.key":{"terms":{"field":"cl_status.key","size":15}},"sourceCatalogue":{"terms":{"field":"sourceCatalogue","size":15}},"isValid":{"terms":{"field":"isValid","size":10}},"isValidInspire":{"terms":{"field":"isValidInspire","size":10}},"groupOwner":{"terms":{"field":"groupOwner","size":10}},"recordOwner":{"terms":{"field":"recordOwner","size":10}},"groupPublished":{"terms":{"field":"groupPublished","size":10}},"documentStandard":{"terms":{"field":"documentStandard","size":10}},"isHarvested":{"terms":{"field":"isHarvested","size":2}},"isTemplate":{"terms":{"field":"isTemplate","size":5}},"isPublishedToAll":{"terms":{"field":"isPublishedToAll","size":2}}}},"admin":{"enabled":true,"appUrl":"../../{{node}}/{{lang}}/admin.console","facetConfig":{"availableInServices":{"filters":{"filters":{"availableInViewService":{"query_string":{"query":"+linkProtocol:/OGC:WMS.*/"}},"availableInDownloadService":{"query_string":{"query":"+linkProtocol:/OGC:WFS.*/"}}}}},"cl_hierarchyLevel.key":{"terms":{"field":"cl_hierarchyLevel.key"},"meta":{"vega":"arc"}},"tag.default":{"terms":{"field":"tag.default","size":10},"meta":{"vega":"arc"}}}},"authentication":{"enabled":false,"signinUrl":"../../{{node}}/{{lang}}/catalog.signin","signoutUrl":"../../signout"},"signin":{"enabled":false,"appUrl":"../../{{node}}/{{lang}}/catalog.signin"},"signout":{"appUrl":"../../signout"},"page":{"enabled":true,"appUrl":"../../{{node}}/{{lang}}/catalog.search#/page"}}}');
+INSERT INTO settings_ui VALUES ('srv', '{
+  "baseURLDetector": {
+    "default": "/geonetwork",
+    "regexp": "^((?:/.+)?)+/.+/[a-z]{2,3}/.+"
+  },
+  "langDetector": {
+    "default": "eng",
+    "fromHtmlTag": false,
+    "regexp": "^(?:/.+)?/.+/([a-z]{2,3})/.+"
+  },
+  "mods": {
+    "admin": {
+      "appUrl": "../../{{node}}/{{lang}}/admin.console",
+      "enabled": true,
+      "facetConfig": {
+        "availableInServices": {
+          "filters": {
+            "filters": {
+              "availableInDownloadService": {
+                "query_string": {
+                  "query": "+linkProtocol:/OGC:WFS.*/"
+                }
+              },
+              "availableInViewService": {
+                "query_string": {
+                  "query": "+linkProtocol:/OGC:WMS.*/"
+                }
+              }
+            }
+          }
+        },
+        "cl_hierarchyLevel.key": {
+          "meta": {
+            "vega": "arc"
+          },
+          "terms": {
+            "field": "cl_hierarchyLevel.key"
+          }
+        },
+        "tag.default": {
+          "meta": {
+            "vega": "arc"
+          },
+          "terms": {
+            "field": "tag.default",
+            "size": 10
+          }
+        }
+      }
+    },
+    "authentication": {
+      "enabled": false,
+      "signinUrl": "../../{{node}}/{{lang}}/catalog.signin",
+      "signoutUrl": "../../signout"
+    },
+    "cookieWarning": {
+      "cookieWarningMoreInfoLink": "",
+      "cookieWarningRejectLink": "",
+      "enabled": false
+    },
+    "editor": {
+      "allowRemoteRecordLink": true,
+      "appUrl": "../../{{node}}/{{lang}}/catalog.edit",
+      "createPageTpl": "../../catalog/templates/editor/new-metadata-horizontal.html",
+      "editorIndentType": "",
+      "enabled": true,
+      "facetConfig": {
+        "cl_status.key": {
+          "terms": {
+            "field": "cl_status.key",
+            "size": 15
+          }
+        },
+        "documentStandard": {
+          "terms": {
+            "field": "documentStandard",
+            "size": 10
+          }
+        },
+        "groupOwner": {
+          "terms": {
+            "field": "groupOwner",
+            "size": 10
+          }
+        },
+        "groupPublished": {
+          "terms": {
+            "field": "groupPublished",
+            "size": 10
+          }
+        },
+        "isHarvested": {
+          "terms": {
+            "field": "isHarvested",
+            "size": 2
+          }
+        },
+        "isPublishedToAll": {
+          "terms": {
+            "field": "isPublishedToAll",
+            "size": 2
+          }
+        },
+        "isTemplate": {
+          "terms": {
+            "field": "isTemplate",
+            "size": 5
+          }
+        },
+        "isValid": {
+          "terms": {
+            "field": "isValid",
+            "size": 10
+          }
+        },
+        "isValidInspire": {
+          "terms": {
+            "field": "isValidInspire",
+            "size": 10
+          }
+        },
+        "recordOwner": {
+          "terms": {
+            "field": "recordOwner",
+            "size": 10
+          }
+        },
+        "resourceType": {
+          "terms": {
+            "field": "resourceType",
+            "size": 20
+          }
+        },
+        "sourceCatalogue": {
+          "terms": {
+            "field": "sourceCatalogue",
+            "size": 15
+          }
+        }
+      },
+      "fluidEditorLayout": true,
+      "isFilterTagsDisplayed": false,
+      "isUserRecordsOnly": false,
+      "minUserProfileToCreateTemplate": ""
+    },
+    "footer": {
+      "enabled": true,
+      "showSocialBarInFooter": true
+    },
+    "geocoder": {
+      "appUrl": "https://secure.geonames.org/searchJSON",
+      "enabled": true
+    },
+    "global": {
+      "dateFormat": "DD-MM-YYYY HH:mm",
+      "humanizeDates": true,
+      "timezone": "Browser"
+    },
+    "header": {
+      "enabled": true,
+      "fluidHeaderLayout": true,
+      "isHeaderFixed": false,
+      "isLogoInHeader": false,
+      "languages": {
+        "cat": "ca",
+        "chi": "zh",
+        "cze": "cs",
+        "dut": "nl",
+        "eng": "en",
+        "fin": "fi",
+        "fre": "fr",
+        "ger": "de",
+        "ice": "is",
+        "ita": "it",
+        "kor": "ko",
+        "por": "pt",
+        "rus": "ru",
+        "slo": "sk",
+        "spa": "es",
+        "swe": "sv"
+      },
+      "logoInHeaderPosition": "left",
+      "showGNName": true
+    },
+    "home": {
+      "appUrl": "../../{{node}}/{{lang}}/catalog.search#/home",
+      "enabled": true,
+      "facetConfig": {
+        "cl_hierarchyLevel.key": {
+          "terms": {
+            "field": "cl_hierarchyLevel.key",
+            "size": 10
+          }
+        },
+        "cl_topic.key": {
+          "terms": {
+            "field": "cl_topic.key",
+            "size": 20
+          }
+        },
+        "inspireThemeUri": {
+          "terms": {
+            "field": "inspireThemeUri",
+            "size": 34
+          }
+        }
+      },
+      "fluidLayout": true,
+      "showSocialBarInFooter": false
+    },
+    "map": {
+      "appUrl": "../../{{node}}/{{lang}}/catalog.search#/map",
+      "autoFitOnLayer": false,
+      "bingKey": "",
+      "disabledTools": {
+        "addLayers": false,
+        "contexts": false,
+        "drawVector": false,
+        "filter": false,
+        "graticule": false,
+        "layers": false,
+        "legend": false,
+        "mInteraction": false,
+        "mousePosition": true,
+        "print": false,
+        "processes": false,
+        "projectionSwitcher": false,
+        "syncAllLayers": false
+      },
+      "enabled": true,
+      "externalViewer": {
+        "baseUrl": "/mapstore/",
+        "enabled": true,
+        "enabledViewAction": false,
+        "openNewWindow": false,
+        "urlTemplate": "/mapstore/#/?actions=[{\"type\":\"CATALOG:ADD_LAYERS_FROM_CATALOGS\",\"layers\":[\"${service.name}\"],\"sources\":[{\"type\":\"${service.type}\",\"url\":\"${service.url}\"}]}]",
+        "valuesSeparator": ","
+      },
+      "graticuleOgcService": {},
+      "is3DModeAllowed": false,
+      "isExportMapAsImageEnabled": false,
+      "isSaveMapInCatalogAllowed": true,
+      "listOfServices": {
+        "wms": [],
+        "wmts": []
+      },
+      "map-editor": {
+        "context": "",
+        "extent": [
+          0,
+          0,
+          0,
+          0
+        ],
+        "layers": [
+          {
+            "type": "osm"
+          }
+        ]
+      },
+      "map-search": {
+        "context": "../../map/config-viewer.xml",
+        "extent": [
+          0,
+          0,
+          0,
+          0
+        ],
+        "layers": []
+      },
+      "map-viewer": {
+        "context": "../../map/config-viewer.xml",
+        "extent": [
+          0,
+          0,
+          0,
+          0
+        ],
+        "layers": []
+      },
+      "projection": "EPSG:3857",
+      "projectionList": [
+        {
+          "code": "urn:ogc:def:crs:EPSG:6.6:4326",
+          "label": "WGS84 (EPSG:4326)"
+        },
+        {
+          "code": "EPSG:3857",
+          "label": "Google mercator (EPSG:3857)"
+        }
+      ],
+      "storage": "sessionStorage",
+      "switcherProjectionList": [
+        {
+          "code": "EPSG:3857",
+          "label": "Google mercator (EPSG:3857)"
+        }
+      ]
+    },
+    "page": {
+      "appUrl": "../../{{node}}/{{lang}}/catalog.search#/page",
+      "enabled": true
+    },
+    "recordview": {
+      "enabled": true,
+      "isSocialbarEnabled": true
+    },
+    "search": {
+      "appUrl": "../../{{node}}/{{lang}}/catalog.search#/search",
+      "autocompleteConfig": {
+        "_source": [
+          "resourceTitleObject"
+        ],
+        "from": 0,
+        "query": {
+          "bool": {
+            "must": [
+              {
+                "multi_match": {
+                  "fields": [
+                    "resourceTitleObject.*",
+                    "resourceAbstractObject.*",
+                    "tag",
+                    "resourceIdentifier"
+                  ],
+                  "query": "",
+                  "type": "bool_prefix"
+                }
+              }
+            ]
+          }
+        },
+        "size": 20
+      },
+      "downloadFormatter": [
+        {
+          "class": "fa-file-zip-o",
+          "label": "exportMEF",
+          "url": "/formatters/zip?withRelated=false"
+        },
+        {
+          "class": "fa-file-pdf-o",
+          "label": "exportPDF",
+          "url": "/formatters/xsl-view?output=pdf&language=${lang}"
+        },
+        {
+          "class": "fa-file-code-o",
+          "label": "exportXML",
+          "url": "/formatters/xml"
+        }
+      ],
+      "enabled": true,
+      "exactMatchToggle": true,
+      "facetConfig": {
+        "OrgForResource": {
+          "meta": {
+            "caseInsensitiveInclude": true
+          },
+          "terms": {
+            "field": "OrgForResource",
+            "include": ".*",
+            "size": 15
+          }
+        },
+        "availableInServices": {
+          "filters": {
+            "filters": {
+              "availableInDownloadService": {
+                "query_string": {
+                  "query": "+linkProtocol:/OGC:WFS.*/"
+                }
+              },
+              "availableInViewService": {
+                "query_string": {
+                  "query": "+linkProtocol:/OGC:WMS.*/"
+                }
+              }
+            }
+          }
+        },
+        "cl_hierarchyLevel.key": {
+          "aggs": {
+            "format": {
+              "terms": {
+                "field": "format"
+              }
+            }
+          },
+          "terms": {
+            "field": "cl_hierarchyLevel.key"
+          }
+        },
+        "cl_maintenanceAndUpdateFrequency.key": {
+          "meta": {
+            "collapsed": true
+          },
+          "terms": {
+            "field": "cl_maintenanceAndUpdateFrequency.key",
+            "size": 10
+          }
+        },
+        "cl_spatialRepresentationType.key": {
+          "terms": {
+            "field": "cl_spatialRepresentationType.key",
+            "size": 10
+          }
+        },
+        "creationYearForResource": {
+          "histogram": {
+            "field": "creationYearForResource",
+            "interval": 5,
+            "keyed": true,
+            "min_doc_count": 1
+          },
+          "meta": {
+            "collapsed": true
+          }
+        },
+        "resolutionScaleDenominator": {
+          "histogram": {
+            "field": "resolutionScaleDenominator",
+            "interval": 10000,
+            "keyed": true,
+            "min_doc_count": 1
+          },
+          "meta": {
+            "collapsed": true
+          }
+        },
+        "tag.default": {
+          "meta": {
+            "caseInsensitiveInclude": true
+          },
+          "terms": {
+            "field": "tag.default",
+            "include": ".*",
+            "size": 10
+          }
+        },
+        "th_gemet_tree.default": {
+          "terms": {
+            "field": "th_gemet_tree.default",
+            "include": "[^^]+^?[^^]+",
+            "order": {
+              "_key": "asc"
+            },
+            "size": 100
+          }
+        },
+        "th_httpinspireeceuropaeumetadatacodelistPriorityDataset-PriorityDataset_tree.default": {
+          "terms": {
+            "field": "th_httpinspireeceuropaeumetadatacodelistPriorityDataset-PriorityDataset_tree.default",
+            "order": {
+              "_key": "asc"
+            },
+            "size": 100
+          }
+        },
+        "th_regions_tree.default": {
+          "terms": {
+            "field": "th_regions_tree.default",
+            "order": {
+              "_key": "asc"
+            },
+            "size": 100
+          }
+        }
+      },
+      "facetTabField": "",
+      "filters": null,
+      "formatter": {
+        "defaultUrl": "",
+        "list": [
+          {
+            "label": "defaultView",
+            "url": ""
+          },
+          {
+            "label": "full",
+            "url": "/formatters/xsl-view?root=div&view=advanced"
+          }
+        ]
+      },
+      "grid": {
+        "related": [
+          "parent",
+          "children",
+          "services",
+          "datasets"
+        ]
+      },
+      "hitsperpageValues": [
+        30,
+        60,
+        120
+      ],
+      "isFilterTagsDisplayedInSearch": true,
+      "isVegaEnabled": true,
+      "linkTypes": {
+        "downloads": [
+          "DOWNLOAD"
+        ],
+        "layers": [
+          "OGC",
+          "ESRI:REST"
+        ],
+        "links": [
+          "LINK",
+          "kml"
+        ],
+        "maps": [
+          "ows"
+        ]
+      },
+      "moreLikeThisConfig": {
+        "more_like_this": {
+          "fields": [
+            "resourceTitleObject.default",
+            "resourceAbstractObject.default",
+            "tag.raw"
+          ],
+          "like": null,
+          "max_query_terms": 12,
+          "min_term_freq": 1
+        }
+      },
+      "paginationInfo": {
+        "hitsPerPage": 30
+      },
+      "queryBase": "any.${searchLang}:(${any}) OR any.common:(${any}) OR resourceTitleObject.${searchLang}:(${any})^2 OR resourceTitleObject.\\*:\"${any}\"^6",
+      "resultTemplate": "../../catalog/components/search/resultsview/partials/viewtemplates/grid.html",
+      "resultViewTpls": [
+        {
+          "icon": "fa-th",
+          "tooltip": "Grid",
+          "tplUrl": "../../catalog/components/search/resultsview/partials/viewtemplates/grid.html"
+        },
+        {
+          "icon": "fa-bars",
+          "tooltip": "List",
+          "tplUrl": "../../catalog/components/search/resultsview/partials/viewtemplates/list.html"
+        }
+      ],
+      "savedSelection": {
+        "enabled": false
+      },
+      "scoreConfig": {
+        "boost": "5",
+        "functions": [
+          {
+            "filter": {
+              "exists": {
+                "field": "parentUuid"
+              }
+            },
+            "weight": 0.3
+          },
+          {
+            "filter": {
+              "match": {
+                "cl_status.key": "obsolete"
+              }
+            },
+            "weight": 0.3
+          },
+          {
+            "gauss": {
+              "dateStamp": {
+                "decay": 0.5,
+                "offset": "90d",
+                "scale": "365d"
+              }
+            }
+          }
+        ],
+        "score_mode": "multiply"
+      },
+      "sortBy": "relevance",
+      "sortbyValues": [
+        {
+          "sortBy": "relevance",
+          "sortOrder": ""
+        },
+        {
+          "sortBy": "dateStamp",
+          "sortOrder": "desc"
+        },
+        {
+          "sortBy": "createDate",
+          "sortOrder": "desc"
+        },
+        {
+          "sortBy": "resourceTitleObject.default.keyword",
+          "sortOrder": ""
+        },
+        {
+          "sortBy": "rating",
+          "sortOrder": "desc"
+        },
+        {
+          "sortBy": "popularity",
+          "sortOrder": "desc"
+        }
+      ],
+      "usersearches": {
+        "displayFeaturedSearchesPanel": false,
+        "enabled": false,
+        "includePortals": true
+      }
+    },
+    "signin": {
+      "appUrl": "../../{{node}}/{{lang}}/catalog.signin",
+      "enabled": false
+    },
+    "signout": {
+      "appUrl": "../../signout"
+    }
+  },
+  "nodeDetector": {
+    "default": "srv",
+    "regexp": "^(?:/.+)?/(.+)/[a-z]{2,3}/.+"
+  },
+  "serviceDetector": {
+    "default": "catalog.search",
+    "regexp": "^(?:/.+)?/.+/[a-z]{2,3}/(.+)"
+  }
+}');
+
 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -912,7 +912,7 @@ INSERT INTO settings_ui VALUES ('srv', '{
       "minUserProfileToCreateTemplate": ""
     },
     "footer": {
-      "enabled": true,
+      "enabled": false,
       "showSocialBarInFooter": true
     },
     "geocoder": {


### PR DESCRIPTION
See https://github.com/georchestra/georchestra/issues/3890 for the main motivation behind this PR.

* fixing search inconsistencies encountered on issue mentioned above
* following migration notes manual steps on https://github.com/georchestra/georchestra/tree/master/migrations/22.0#geonetwork-4
  * mapstore as map viewer
  * deactivating auth panel

Tests: mainly runtime tested on a fresh docker composition, along with a customized GN image (including the modification suggested here). GN to Mapstore link tested with with a dataset published via the DataFeeder.

Note: Having the UI config multilined instead of as minified json, because:
1. we will derive from upstream anyway with such a change
2. I think that if we have other things at the same place to customize, maybe it will be easier in a more human-readable fashion.

