### PR TITLE
ODS: Copy ods themes to topicCategory instead of keywords

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
@@ -296,9 +296,18 @@
                 </mri:equivalentScale>
               </mri:MD_Resolution>
             </mri:spatialResolution>-->
-            <mri:topicCategory>
-              <mri:MD_TopicCategoryCode></mri:MD_TopicCategoryCode>
-            </mri:topicCategory>
+
+            <!-- ODS themes copied as topicCategory -->
+            <xsl:if test="metas/theme">
+                <xsl:for-each select="metas/theme">
+                  <mri:topicCategory>
+                    <mri:MD_TopicCategoryCode>
+                      <xsl:value-of select="."/>
+                    </mri:MD_TopicCategoryCode>
+                  </mri:topicCategory>
+                </xsl:for-each>
+            </xsl:if>
+
             <!--<mri:extent>
               <gex:EX_Extent>
                 <gex:temporalElement>
@@ -366,25 +375,6 @@
                       </gco:CharacterString>
                     </mri:keyword>
                   </xsl:for-each>
-                </mri:MD_Keywords>
-              </mri:descriptiveKeywords>
-            </xsl:if>
-
-            <!-- ODS themes copied as keywords with type 'theme' -->
-            <xsl:if test="metas/theme">
-              <mri:descriptiveKeywords>
-                <mri:MD_Keywords>
-                  <xsl:for-each select="metas/theme">
-                    <mri:keyword>
-                      <gco:CharacterString>
-                        <xsl:value-of select="."/>
-                      </gco:CharacterString>
-                    </mri:keyword>
-                  </xsl:for-each>
-                  <mri:type>
-                    <mri:MD_KeywordTypeCode codeListValue="theme"
-                                            codeList="./resources/codeList.xml#MD_KeywordTypeCode"/>
-                  </mri:type>
                 </mri:MD_Keywords>
               </mri:descriptiveKeywords>
             </xsl:if>


### PR DESCRIPTION
PR copies the ODS themes to `topicCategory` instead of the keywords.

For the record: An issue within this PR that inserted carriage returns during indexation was resolved by removing `<gco:CharacterString>` around the value select. Thanks, @jahow !