### PR TITLE
Support http links in the Géo-IDE transformation

### DIFF
--- a/web/src/main/webapp/xsl/conversion/import/GeoIDE-services-OGC.xsl
+++ b/web/src/main/webapp/xsl/conversion/import/GeoIDE-services-OGC.xsl
@@ -12,7 +12,7 @@
 
     <!-- traitement spécial pour les éléments gmd:online -->
     <xsl:template match="gmd:onLine">
-        <xsl:variable name="url" select="gmd:CI_OnlineResource/gmd:linkage/gmd:URL"/>
+        <xsl:variable name="url" select="replace(gmd:CI_OnlineResource/gmd:linkage/gmd:URL, 'http://', 'https://')"/>
         <xsl:variable name="layerName" select="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:alternateTitle"/>
 
         <!-- il s'agit d'une url de base de services WxS : créer deux liens explicites pour WMS et WFS -->


### PR DESCRIPTION
This simple change to Géo-IDE records makes it so that links using the `http://` protocol  are automatically upgraded to `https://`, for which there is already a redirection on the Géo-IDE side.

Handling this upgrade during harvesting avoids getting a 301 redirection later on when downloading the data for the datahub, as the 301 redirection will bypass the proxy and make a CORS error show up.

To see a record which advertises WxS services in HTTP: http://catalogue.geo-ide.developpement-durable.gouv.fr/catalogue/srv/api/records/fr-120066022-jdd-0b5c2019-2bc1-4188-8a7c-bcb8630c1073/formatters/xml
![image](https://github.com/georchestra/geonetwork/assets/10629150/5b6fe48b-9d6d-47da-a381-828fc49f9f29)


Using the modified transformation part of this PR, this gives: https://dev.geo2france.fr/geonetwork/srv/api/records/fr-120066022-jdd-0b5c2019-2bc1-4188-8a7c-bcb8630c1073/formatters/xml?approved=true
![image](https://github.com/georchestra/geonetwork/assets/10629150/98b1b281-a387-489e-907a-b2a822f1f17b)
