### PR TITLE
[BP] JS / Moment / Timezone lib missing when 3D mode enabled (#6603)

### DIFF
--- a/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
+++ b/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
@@ -104,6 +104,7 @@
     <jsSource webappPath="/catalog/lib/modernizr.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/jquery-2.2.4.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/moment+langs.min.js" minimize="false"/>
+    <jsSource webappPath="/catalog/lib/moment-timezone-with-data-10-year-range.min.js" minimize="false" />
     <jsSource webappPath="/catalog/lib/angular/angular.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/angular-filter.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/angular/angular-resource.min.js" minimize="false"/>


### PR DESCRIPTION
PR backports fix from main.

Related to https://github.com/geonetwork/core-geonetwork/pull/4576

Error reported
```
TypeError: Cannot read properties of undefined (reading 'guess')
```