### PR TITLE
ODS: Align XSL with upstream

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
@@ -73,7 +73,7 @@
           <mcc:MD_Identifier>
             <mcc:code>
               <gco:CharacterString>
-                <xsl:value-of select="datasetid"/>
+                <xsl:value-of select="(datasetid|dataset/dataset_id)[1]"/>
               </gco:CharacterString>
             </mcc:code>
           </mcc:MD_Identifier>
@@ -81,18 +81,21 @@
         <mdb:defaultLocale>
           <lan:PT_Locale>
             <lan:language>
-              <lan:LanguageCode codeList="codeListLocation#LanguageCode" codeListValue="{java-xsl-util:threeCharLangCode(metas/language)}"/>
+              <lan:LanguageCode codeList="codeListLocation#LanguageCode"
+                                codeListValue="{java-xsl-util:threeCharLangCode(
+                                (metas/language|dataset/metas/default/metadata_languages)[1])}"/>
             </lan:language>
             <lan:characterEncoding>
               <lan:MD_CharacterSetCode codeList="codeListLocation#MD_CharacterSetCode"
-                                       codeListValue=""/>
+                                       codeListValue="utf8"/>
             </lan:characterEncoding>
           </lan:PT_Locale>
         </mdb:defaultLocale>
         <mdb:metadataScope>
           <mdb:MD_MetadataScope>
             <mdb:resourceScope>
-              <mcc:MD_ScopeCode codeList="" codeListValue="{@type}"/>
+              <mcc:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode"
+                                codeListValue="{if (@type) then @type else 'dataset'}"/>
             </mdb:resourceScope>
           </mdb:MD_MetadataScope>
         </mdb:metadataScope>
@@ -106,7 +109,7 @@
               <cit:CI_Organisation>
                 <cit:name>
                   <gco:CharacterString>
-                    <xsl:value-of select="metas/publisher"/>
+                    <xsl:value-of select="(metas/publisher|dataset/metas/default/publisher)[1]"/>
                   </gco:CharacterString>
                 </cit:name>
                 <cit:contactInfo>
@@ -130,17 +133,7 @@
         <mdb:dateInfo>
           <cit:CI_Date>
             <cit:date>
-              <gco:DateTime><xsl:value-of select="metas/modified"/></gco:DateTime>
-            </cit:date>
-            <cit:dateType>
-              <cit:CI_DateTypeCode codeList="codeListLocation#CI_DateTypeCode" codeListValue="creation"/>
-            </cit:dateType>
-          </cit:CI_Date>
-        </mdb:dateInfo>
-        <mdb:dateInfo>
-          <cit:CI_Date>
-            <cit:date>
-              <gco:DateTime><xsl:value-of select="metas/modified"/></gco:DateTime>
+              <gco:DateTime><xsl:value-of select="(metas/modified|dataset/metas/default/metadata_processed)[1]"/></gco:DateTime>
             </cit:date>
             <cit:dateType>
               <cit:CI_DateTypeCode codeList="codeListLocation#CI_DateTypeCode" codeListValue="publication"/>
@@ -164,30 +157,21 @@
             </cit:title>
           </cit:CI_Citation>
         </mdb:metadataStandard>
-        <!--<mdb:referenceSystemInfo>
-          <mrs:MD_ReferenceSystem>
-            <mrs:referenceSystemIdentifier>
-              <mcc:MD_Identifier>
-                <mcc:code>
-                  <gco:CharacterString>WGS 1984</gco:CharacterString>
-                </mcc:code>
-              </mcc:MD_Identifier>
-            </mrs:referenceSystemIdentifier>
-          </mrs:MD_ReferenceSystem>
-        </mdb:referenceSystemInfo>-->
         <mdb:identificationInfo>
           <mri:MD_DataIdentification>
             <mri:citation>
               <cit:CI_Citation>
                 <cit:title>
                   <gco:CharacterString>
-                    <xsl:value-of select="metas/title"/>
+                    <xsl:value-of select="(metas/title|dataset/metas/default/title)[1]"/>
                   </gco:CharacterString>
                 </cit:title>
                 <cit:date>
                   <cit:CI_Date>
                     <cit:date>
-                      <gco:DateTime><xsl:value-of select="metas/modified"/></gco:DateTime>
+                      <gco:DateTime>
+                        <xsl:value-of select="(metas/modified|dataset/metas/default/modified)[1]"/>
+                      </gco:DateTime>
                     </cit:date>
                     <cit:dateType>
                       <cit:CI_DateTypeCode codeList="codeListLocation#CI_DateTypeCode" codeListValue="publication"/>
@@ -208,7 +192,7 @@
             </mri:citation>
             <mri:abstract>
               <gco:CharacterString>
-                <xsl:value-of select="metas/description"/>
+                <xsl:value-of select="(metas/description|dataset/metas/default/description)[1]"/>
               </gco:CharacterString>
             </mri:abstract>
             <!-- TODO: Check state definition-->
@@ -248,7 +232,6 @@
                 </cit:CI_Responsibility>
               </mri:pointOfContact>
             </xsl:if>
-
             <xsl:for-each select="organization">
               <mri:pointOfContact>
                 <cit:CI_Responsibility>
@@ -281,22 +264,6 @@
               </mri:pointOfContact>
             </xsl:for-each>
 
-
-            <!--<mri:spatialRepresentationType>
-              <mcc:MD_SpatialRepresentationTypeCode codeList="" codeListValue=""/>
-            </mri:spatialRepresentationType>
-            <mri:spatialResolution>
-              <mri:MD_Resolution>
-                <mri:equivalentScale>
-                  <mri:MD_RepresentativeFraction>
-                    <mri:denominator>
-                      <gco:Integer/>
-                    </mri:denominator>
-                  </mri:MD_RepresentativeFraction>
-                </mri:equivalentScale>
-              </mri:MD_Resolution>
-            </mri:spatialResolution>-->
-
             <!-- ODS themes copied as topicCategory -->
             <xsl:if test="metas/theme">
                 <xsl:for-each select="metas/theme">
@@ -308,67 +275,13 @@
                 </xsl:for-each>
             </xsl:if>
 
-            <!--<mri:extent>
-              <gex:EX_Extent>
-                <gex:temporalElement>
-                  <gex:EX_TemporalExtent>
-                    <gex:extent>
-                      <gml:TimePeriod gml:id="A1234">
-                        <gml:beginPosition>
-                        </gml:beginPosition>
-                        <gml:endPosition>
-                        </gml:endPosition>
-                      </gml:TimePeriod>
-                    </gex:extent>
-                  </gex:EX_TemporalExtent>
-                </gex:temporalElement>
-              </gex:EX_Extent>
-            </mri:extent>-->
-            <!--
-            geographic_area: {
-              type: "Polygon",
-              coordinates: [
-              [
-              [
-              2.3642042812,
-              48.816398324
-
-            <mri:extent>
-              <gex:EX_Extent>
-                <gex:geographicElement>
-                  <gex:EX_GeographicBoundingBox>
-                    <gex:westBoundLongitude>
-                      <gco:Decimal>-180</gco:Decimal>
-                    </gex:westBoundLongitude>
-                    <gex:eastBoundLongitude>
-                      <gco:Decimal>180</gco:Decimal>
-                    </gex:eastBoundLongitude>
-                    <gex:southBoundLatitude>
-                      <gco:Decimal>-90</gco:Decimal>
-                    </gex:southBoundLatitude>
-                    <gex:northBoundLatitude>
-                      <gco:Decimal>90</gco:Decimal>
-                    </gex:northBoundLatitude>
-                  </gex:EX_GeographicBoundingBox>
-                </gex:geographicElement>
-              </gex:EX_Extent>
-            </mri:extent>-->
-
-
-            <!--<mri:resourceMaintenance>
-              <mmi:MD_MaintenanceInformation>
-                <mmi:maintenanceAndUpdateFrequency>
-                  <mmi:MD_MaintenanceFrequencyCode codeListValue="asNeeded"
-                                                   codeList="./resources/codeList.xml#MD_MaintenanceFrequencyCode"/>
-                </mmi:maintenanceAndUpdateFrequency>
-              </mmi:MD_MaintenanceInformation>
-            </mri:resourceMaintenance>-->
-
             <!-- ODS keywords copied without type -->
-            <xsl:if test="metas/keyword">
+            <xsl:variable name="keywords"
+                          select="metas/keyword|dataset/metas/default/keyword"/>
+            <xsl:if test="$keywords">
               <mri:descriptiveKeywords>
                 <mri:MD_Keywords>
-                  <xsl:for-each select="metas/keyword">
+                  <xsl:for-each select="$keywords">
                     <mri:keyword>
                       <gco:CharacterString>
                         <xsl:value-of select="."/>
@@ -388,14 +301,14 @@
                   <cit:CI_Citation>
                     <cit:title>
                       <gco:CharacterString>
-                        <xsl:value-of select="metas/license"/>
+                        <xsl:value-of select="metas/license|dataset/meta/default/license"/>
                       </gco:CharacterString>
                     </cit:title>
                     <cit:onlineResource>
                       <cit:CI_OnlineResource>
                         <cit:linkage>
                           <gco:CharacterString>
-                            <xsl:value-of select="metas/license_url"/>
+                            <xsl:value-of select="metas/license_url|dataset/meta/default/license_url"/>
                           </gco:CharacterString>
                         </cit:linkage>
                       </cit:CI_OnlineResource>
@@ -412,7 +325,7 @@
                 </mco:useConstraints>
                 <mco:otherConstraints>
                   <gco:CharacterString>
-                    <xsl:value-of select="metas/license"/>
+                    <xsl:value-of select="metas/license|dataset/meta/default/license"/>
                   </gco:CharacterString>
                 </mco:otherConstraints>
               </mco:MD_LegalConstraints>
@@ -422,7 +335,7 @@
             <mri:defaultLocale>
               <lan:PT_Locale>
                 <lan:language>
-                  <lan:LanguageCode codeList="codeListLocation#LanguageCode" codeListValue="{java-xsl-util:threeCharLangCode(metas/language)}"/>
+                  <lan:LanguageCode codeList="codeListLocation#LanguageCode" codeListValue="{java-xsl-util:threeCharLangCode((metas/language|dataset/meta/default/language)[1])}"/>
                 </lan:language>
                 <lan:characterEncoding>
                   <lan:MD_CharacterSetCode codeList="codeListLocation#MD_CharacterSetCode"
@@ -443,7 +356,7 @@
           name: "n_sq_fil"
           },
         -->
-        <xsl:if test="count(fields) > 0">
+        <xsl:if test="count(fields|dataset/fields) > 0">
           <mdb:contentInfo>
             <mrc:MD_FeatureCatalogue>
               <mrc:featureCatalogue>
@@ -451,11 +364,13 @@
                   <gfc:producer></gfc:producer>
                   <gfc:featureType>
                     <gfc:FC_FeatureType>
-                      <gfc:typeName><xsl:value-of select="metas/title"/></gfc:typeName>
+                      <gfc:typeName>
+                        <xsl:value-of select="(metas/title|dataset/metas/default/title)[1]"/>
+                      </gfc:typeName>
                       <gfc:isAbstract>
                         <gco:Boolean>false</gco:Boolean>
                       </gfc:isAbstract>
-                      <xsl:for-each select="fields">
+                      <xsl:for-each select="fields|dataset/fields">
                         <gfc:carrierOfCharacteristics>
                           <gfc:FC_FeatureAttribute>
                             <gfc:memberName>
@@ -538,7 +453,7 @@
 
             <mrd:transferOptions>
               <mrd:MD_DigitalTransferOptions>
-                <xsl:for-each select="attachments">
+                <xsl:for-each select="attachments|dataset/attachments">
                   <mrd:onLine>
                     <cit:CI_OnlineResource>
                       <cit:linkage>
@@ -566,20 +481,22 @@
                 </xsl:for-each>
 
                 <!-- Data download links are inferred from the record metadata -->
-                <xsl:if test="metas/records_count > 0">
+                <xsl:variable name="count"
+                              select="metas/records_count|dataset/metas/default/records_count"/>
+                <xsl:if test="$count > 0">
                   <xsl:call-template name="dataLink">
                     <xsl:with-param name="format">csv</xsl:with-param>
                   </xsl:call-template>
                   <xsl:call-template name="dataLink">
                     <xsl:with-param name="format">json</xsl:with-param>
                   </xsl:call-template>
-                  <xsl:if test="count(features[. = 'geo']) > 0">
+                  <xsl:if test="count(.//features[. = 'geo']) > 0">
                     <xsl:call-template name="dataLink">
                       <xsl:with-param name="format">geojson</xsl:with-param>
                     </xsl:call-template>
-                    <xsl:if test="metas/records_count &lt; 5000">
+                    <xsl:if test="$count &lt; 5000">
                       <xsl:call-template name="dataLink">
-                        <xsl:with-param name="format">shapefile</xsl:with-param>
+                        <xsl:with-param name="format">shp</xsl:with-param>
                       </xsl:call-template>
                     </xsl:if>
                   </xsl:if>
@@ -593,7 +510,10 @@
                   <cit:CI_OnlineResource>
                     <cit:linkage>
                       <gco:CharacterString>
-                        <xsl:value-of select="concat(nodeUrl, '/explore/dataset/', datasetid, '/information/')" />
+                        <xsl:value-of select="concat(nodeUrl,
+                                          '/explore/dataset/',
+                                          (datasetid|dataset/dataset_id)[1],
+                                           '/information/')" />
                       </gco:CharacterString>
                     </cit:linkage>
                     <cit:protocol>
@@ -641,7 +561,10 @@
         <cit:CI_OnlineResource>
           <cit:linkage>
             <gco:CharacterString>
-              <xsl:value-of select="concat(nodeUrl, '/explore/dataset/', datasetid, '/download?format=', $format, '&amp;timezone=Europe/Berlin&amp;use_labels_for_header=false')" />
+              <xsl:value-of select="concat(nodeUrl,
+                                   '/api/explore/v2.1/catalog/datasets/',
+                                   (datasetid|dataset/dataset_id)[1],
+                                   '/exports/', $format, '?use_labels=true')" />
             </gco:CharacterString>
           </cit:linkage>
           <cit:protocol>
@@ -661,7 +584,7 @@
           </cit:description>
           <cit:function>
             <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
-                                       codeListValue="fileAccess"/>
+                                       codeListValue="download"/>
           </cit:function>
         </cit:CI_OnlineResource>
       </mrd:onLine>


### PR DESCRIPTION
PR aligns ODS XSL with upstream, including the changes from PR https://github.com/geonetwork/core-geonetwork/pull/7253, basically:

- adding support for ODS v2 
- inserting ODS explore API urls (which respond with Access-Control-Allow-Origin:* CORS headers) for `OnlineResource` `linkages`