### PR TITLE
georchestra-integration - Synchronizing mails for organizations

### DIFF
--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/AbstractGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/AbstractGroupSynchronizer.java
@@ -134,7 +134,7 @@ abstract class AbstractGroupSynchronizer implements GroupSynchronizer {
             Group group = this.gnGroupRepository.findByName(canonical.getName());
             if (null == group) {
                 group = new Group();
-                log.info("Creatinng GN group {} (Id: {}, version '{}')", //
+                log.info("Creating GN group {} (Id: {}, version '{}')", //
                         canonical.getName(), canonical.getId(), canonical.getLastUpdated());
             } else {
                 log.info("Reconciling existing GN group {} with canonical group (id: {})", group.getName(),
@@ -157,6 +157,7 @@ abstract class AbstractGroupSynchronizer implements GroupSynchronizer {
         group.setName(canonical.getName());
         group.setDescription(canonical.getDescription());
         group.setWebsite(canonical.getLinkage());
+        group.setEmail(canonical.getMail());
         link.setCanonical(canonical);
         link = externalGroupLinks.save(link);
         assert link.isUpToDateWith(canonical);

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/model/CanonicalGroup.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/model/CanonicalGroup.java
@@ -68,6 +68,8 @@ public interface CanonicalGroup {
      */
     String getLinkage();
 
+    String getMail();
+
     static CanonicalGroupImpl.Builder builder() {
         return CanonicalGroupImpl.builder();
     }

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/model/CanonicalGroupImpl.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/model/CanonicalGroupImpl.java
@@ -41,6 +41,7 @@ public class CanonicalGroupImpl implements CanonicalGroup {
     private String linkage;
     private String orgTitle;
 
+    private String orgMail;
     private GroupSyncMode origin;
 
     @Generated("SparkTools")
@@ -52,6 +53,7 @@ public class CanonicalGroupImpl implements CanonicalGroup {
         this.lastUpdated = builder.lastUpdated;
         this.origin = builder.origin;
         this.orgTitle = builder.orgTitle;
+        this.orgMail = builder.orgMail;
     }
 
     public @Override String getId() {
@@ -77,6 +79,9 @@ public class CanonicalGroupImpl implements CanonicalGroup {
     public @Override String getLinkage() {
         return linkage;
     }
+
+    @Override
+    public String getMail() { return orgMail; }
 
     public @Override String getLastUpdated() {
         return lastUpdated;
@@ -122,6 +127,8 @@ public class CanonicalGroupImpl implements CanonicalGroup {
         private String linkage;
         private String lastUpdated;
         private String orgTitle;
+
+        private String orgMail;
         private GroupSyncMode origin;
 
         private Builder() {
@@ -135,6 +142,7 @@ public class CanonicalGroupImpl implements CanonicalGroup {
             this.linkage = group.getLinkage();
             this.lastUpdated = group.getLastUpdated();
             this.origin = group.getOrigin();
+            this.orgMail = group.getMail();
             return this;
         }
 
@@ -172,6 +180,12 @@ public class CanonicalGroupImpl implements CanonicalGroup {
             this.origin = origin;
             return this;
         }
+
+        public Builder withMail(String mail) {
+            this.orgMail = mail;
+            return this;
+        }
+
 
         public CanonicalGroup build() {
             return new CanonicalGroupImpl(this);

--- a/georchestra-integration/georchestra-authnz/src/main/java/org/georchestra/geonetwork/security/integration/CanonicalModelMapper.java
+++ b/georchestra-integration/georchestra-authnz/src/main/java/org/georchestra/geonetwork/security/integration/CanonicalModelMapper.java
@@ -55,6 +55,7 @@ public class CanonicalModelMapper {
                 .withLastUpdated(org.getLastUpdated())//
                 .withLinkage(org.getLinkage())//
                 .withOrigin(GroupSyncMode.orgs)//
+                .withMail(org.getMail())//
                 .build();
     }
 

--- a/georchestra-integration/pom.xml
+++ b/georchestra-integration/pom.xml
@@ -12,7 +12,7 @@
   <name>geOrchestra integration</name>
   <properties>
     <rootProjectDir>${basedir}/..</rootProjectDir>
-    <georchestra.version>23.0.3-SNAPSHOT</georchestra.version>
+    <georchestra.version>23.1-SNAPSHOT</georchestra.version>
   </properties>
   <modules>
     <module>georchestra-utils</module>


### PR DESCRIPTION
this PR will require the following PR to be merged in geOrchestra first:
https://github.com/georchestra/georchestra/pull/4028

Runtime tested with a local docker composition, the `geonetwork.Groups` table looking like the following afterwards:

```
georchestra=# select * from geonetwork.groups;
 id  |         description         |           email            | enablecategoriesrestriction |                 logo                 |   name   | referrer |           website            | defaultcategory_id
-----+-----------------------------+----------------------------+-----------------------------+--------------------------------------+----------+----------+------------------------------+--------------------
  -1 | self-registered users       |                            | n                           |                                      | GUEST    |          |                              |
   0 |                             |                            | n                           |                                      | intranet |          |                              |
   1 |                             |                            | n                           |                                      | all      |          |                              |
   2 |                             |                            | n                           |                                      | sample   |          |                              |
 100 | Camptocamp SAS France       | georchestra@camptocamp.com | n                           |                                      | C2C      |          | https://www.camptocamp.com/  |
 101 | Association PSC geOrchestra | psc@georchestra.org        | n                           | bddf474d-125d-4b18-92bd-bd8ebb6699a9 | PSC      |          | https://www.georchestra.org/ |
(6 rows)
```
