### PR TITLE
Attempt to fix CSW GetRecords issue from mapstore

### DIFF
--- a/.github/workflows/georchestra-gn4.yml
+++ b/.github/workflows/georchestra-gn4.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - georchestra-gn4.2.x
+  pull_request:
+  workflow_dispatch:
 
 env:
   DOCKER_TAG: 4.2.x
@@ -60,22 +62,26 @@ jobs:
         -DdockerImageName=georchestra/geonetwork:${DOCKER_TAG} -DskipTests
 
     - name: "publish the webapp as artifact"
+      if: github.repository == 'georchestra/geonetwork' && github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/georchestra-gn4.2.x' && github.event_name != 'pull_request'
       uses: actions/upload-artifact@v1
       with:
         name: geonetwork.war
         path: web/target/geonetwork.war
 
     - name: "Login onto docker-hub"
+      if: github.repository == 'georchestra/geonetwork' && github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/georchestra-gn4.2.x' && github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
     - name: "Pushing branch image to docker-hub"
+      if: github.repository == 'georchestra/geonetwork' && github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/georchestra-gn4.2.x' && github.event_name != 'pull_request'
       run: |
         docker push georchestra/geonetwork:${DOCKER_TAG}
 
     - name: "Pushing latest image to docker-hub"
+      if: github.repository == 'georchestra/geonetwork' && github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/georchestra-gn4.2.x' && github.event_name != 'pull_request'
       run: |
         docker tag georchestra/geonetwork:${DOCKER_TAG} georchestra/geonetwork:latest
         docker push georchestra/geonetwork:latest

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
@@ -363,7 +363,7 @@ public class CswFilter2Es extends AbstractFilterVisitor {
         String dataPropertyValue = stack.pop();
         String dataPropertyName = stack.pop();
 
-        final String filterEqualTo = String.format(templateMatch, dataPropertyName, dataPropertyValue);
+        final String filterEqualTo = String.format(templateMatch, dataPropertyName, dataPropertyValue.replaceAll("\\/", "\\\\\\\\/"));
         stack.push(filterEqualTo);
 
         return this;
@@ -463,7 +463,7 @@ public class CswFilter2Es extends AbstractFilterVisitor {
 
     /**
      * Fills out the templateSpatial.
-     * 
+     *
      * @param shapeType For example "bbox" or "polygon".
      * @param coords    The coordinates in the form needed by shapeType.
      * @param relation  Spatial operation, like "intersects".

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
@@ -201,18 +201,16 @@ public class CswFilter2Es extends AbstractFilterVisitor {
     protected static String convertLikePattern(PropertyIsLike filter) {
         String result = filter.getLiteral();
         if (!filter.getWildCard().equals("*")) {
-            final String wildcardRe =
-                StringUtils.isNotEmpty(filter.getEscape())
-                    ? Pattern.quote(filter.getEscape() + filter.getWildCard())
-                    : filter.getWildCard();
+            final String wildcardRe = "(?<!" + Pattern.quote(filter.getEscape()) + ")" + Pattern.quote(filter.getWildCard());
             result = result.replaceAll(wildcardRe, "*");
         }
         if (!filter.getSingleChar().equals("?")) {
-            final String singleCharRe =
-                StringUtils.isNotEmpty(filter.getEscape())
-                    ? Pattern.quote(filter.getEscape() + filter.getSingleChar())
-                    : filter.getSingleChar();
+            final String singleCharRe = "(?<!" + Pattern.quote(filter.getEscape()) + ")" + Pattern.quote(filter.getSingleChar());
             result = result.replaceAll(singleCharRe, "?");
+        }
+        if (!filter.getEscape().equals("\\")) {
+            final String escapeRe = Pattern.quote(filter.getEscape()) + "(.)";
+            result = result.replaceAll(escapeRe, "\\\\$1");
         }
         return result;
     }
@@ -465,7 +463,7 @@ public class CswFilter2Es extends AbstractFilterVisitor {
 
     /**
      * Fills out the templateSpatial.
-     *
+     * 
      * @param shapeType For example "bbox" or "polygon".
      * @param coords    The coordinates in the form needed by shapeType.
      * @param relation  Spatial operation, like "intersects".

--- a/georchestra-integration/externalized-accounts/src/test/resources/logback.xml
+++ b/georchestra-integration/externalized-accounts/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <!-- The following logger can be used for containers logs since 1.18.0 -->
+    <logger name="tc" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>

--- a/georchestra-integration/georchestra-authnz/src/test/resources/logback.xml
+++ b/georchestra-integration/georchestra-authnz/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <!-- The following logger can be used for containers logs since 1.18.0 -->
+    <logger name="tc" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>


### PR DESCRIPTION
On current georchestra's geonetwork version (based of GN4.2), the following payload on the CSW endpoint (generated from the mapstore UI when trying to add a layer from the local catalogue) is translated to an invalid query sent to Elasticsearch:

```xml
<?xml version="1.0"?>
<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:ows="http://www.opengis.net/ows" service="CSW" version="2.0.2" resultType="results" startPosition="1" maxRecords="4">
  <csw:Query typeNames="csw:Record">
    <csw:ElementSetName>full</csw:ElementSetName>
    <csw:Constraint version="1.1.0">
      <ogc:Filter>
        <ogc:Or>
          <ogc:PropertyIsEqualTo>
            <ogc:PropertyName>dc:type</ogc:PropertyName>
            <ogc:Literal>dataset</ogc:Literal>
          </ogc:PropertyIsEqualTo>
          <ogc:PropertyIsEqualTo>
            <ogc:PropertyName>dc:type</ogc:PropertyName>
            <ogc:Literal>http://purl.org/dc/dcmitype/Dataset</ogc:Literal>
          </ogc:PropertyIsEqualTo>
        </ogc:Or>
      </ogc:Filter>
    </csw:Constraint>
  </csw:Query>
</csw:GetRecords>
```

It turns out it works if the purl.org url is double-quoted. @cmangeat already provided a fix into an "unofficial" branch from this repository. This PR is just about cherry-picking the work and attempt to fix the IT testsuite.
