### PR TITLE
Update ogc api features key

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
@@ -448,7 +448,7 @@
           "metadataStore": {
             "label": "searchAservice",
             "params": {
-              "serviceType": ["OGC API - Features"]
+              "serviceType": ["OGC API Features"]
             }
           }
         },
@@ -458,7 +458,7 @@
             "isMultilingual": false
           },
           "protocol": {
-            "value": "OGC API - Features",
+            "value": "OGC API Features",
             "hidden": true,
             "isMultilingual": false
           },

--- a/schemas/iso19115-3.2018/src/test/resources/metadata-for-editing-light.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/metadata-for-editing-light.xml
@@ -5080,7 +5080,7 @@ la non-évaluation</b>, dans le cadre de métadonnées INSPIRE]]></help>
             <help>Protocole de connexion utilisé, par exemple FTP.</help>
             <condition />
             <helper sort="true">
-              <option value="OGC API - Features">OGC API - Features</option>
+              <option value="OGC API Features">OGC API - Features</option>
               <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
               <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
               <option value="OGC:GML">OGC-GML Geography Markup Language</option>
@@ -12138,7 +12138,7 @@ la non-évaluation</b>, dans le cadre de métadonnées INSPIRE]]></help>
             <help>Protocole de connexion utilisé, par exemple FTP.</help>
             <condition />
             <helper>
-              <option value="OGC API - Features">OGC API - Features</option>
+              <option value="OGC API Features">OGC API - Features</option>
               <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
               <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
               <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19115-3.2018/src/test/resources/metadata-for-editing.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/metadata-for-editing.xml
@@ -23601,7 +23601,7 @@ la non-évaluation</b>, dans le cadre de métadonnées INSPIRE]]></help>
             <help>Protocole de connexion utilisé, par exemple FTP.</help>
             <condition />
             <helper sort="true">
-              <option value="OGC API - Features">OGC API - Features</option>
+              <option value="OGC API Features">OGC API - Features</option>
               <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
               <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
               <option value="OGC:GML">OGC-GML Geography Markup Language</option>
@@ -30659,7 +30659,7 @@ la non-évaluation</b>, dans le cadre de métadonnées INSPIRE]]></help>
             <help>Protocole de connexion utilisé, par exemple FTP.</help>
             <condition />
             <helper>
-              <option value="OGC API - Features">OGC API - Features</option>
+              <option value="OGC API Features">OGC API - Features</option>
               <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
               <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
               <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19115-3.2018/src/test/resources/metadata-iso19139-for-editing.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/metadata-iso19139-for-editing.xml
@@ -23601,7 +23601,7 @@ la non-évaluation</b>, dans le cadre de métadonnées INSPIRE]]></help>
             <help>Protocole de connexion utilisé, par exemple FTP.</help>
             <condition />
             <helper sort="true">
-              <option value="OGC API - Features">OGC API - Features</option>
+              <option value="OGC API Features">OGC API - Features</option>
               <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
               <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
               <option value="OGC:GML">OGC-GML Geography Markup Language</option>
@@ -30659,7 +30659,7 @@ la non-évaluation</b>, dans le cadre de métadonnées INSPIRE]]></help>
             <help>Protocole de connexion utilisé, par exemple FTP.</help>
             <condition />
             <helper>
-              <option value="OGC API - Features">OGC API - Features</option>
+              <option value="OGC API Features">OGC API - Features</option>
               <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
               <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
               <option value="OGC:GML">OGC-GML Geography Markup Language</option>


### PR DESCRIPTION
In order to be as close as upstream version, renamed `OGC API - Features` key into `OGC API Features`

Initial PR : 
- https://github.com/georchestra/geonetwork/pull/256
