### PR TITLE
Attempt fix csw

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
@@ -449,7 +449,7 @@ public class SearchController {
 
         try {
             String filterQueryString = esFilterBuilder.build(context, "metadata", false, node);
-            String jsonQuery = String.format(elasticSearchQuery, filterQueryString);
+            String jsonQuery = StringUtils.replace(elasticSearchQuery, "\"%s\"", "\"" + filterQueryString + "\"");
 
             ObjectMapper objectMapper = new ObjectMapper();
             esJsonQuery = objectMapper.readTree(jsonQuery);

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
@@ -449,7 +449,7 @@ public class SearchController {
 
         try {
             String filterQueryString = esFilterBuilder.build(context, "metadata", false, node);
-            String jsonQuery = StringUtils.replace(elasticSearchQuery, "\"%s\"", "\"" + filterQueryString + "\"");
+            String jsonQuery = StringUtils.replace(elasticSearchQuery, "{@}", filterQueryString);
 
             ObjectMapper objectMapper = new ObjectMapper();
             esJsonQuery = objectMapper.readTree(jsonQuery);

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
@@ -67,7 +67,7 @@ public class CswFilter2Es extends AbstractFilterVisitor {
         "            \"must\": [\n" +
         "             %s\n" +
         "            ]\n" +
-        "          ,\"filter\":{\"query_string\":{\"query\":\"%s\"}}}"; //, "minimum_should_match" : 1
+        "          ,\"filter\":{\"query_string\":{\"query\":\"{@}\"}}}"; //, "minimum_should_match" : 1
     private static final String TEMPLATE_OR = " {\"bool\": {\n" +
         "            \"should\": [\n" +
         "             %s\n" +
@@ -77,7 +77,7 @@ public class CswFilter2Es extends AbstractFilterVisitor {
         "            \"should\": [\n" +
         "             %s\n" +
         "            ]\n" +
-        "          ,\"filter\":{\"query_string\":{\"query\":\"%s\"}}, \"minimum_should_match\" : 1}";
+        "          ,\"filter\":{\"query_string\":{\"query\":\"{@}\"}}, \"minimum_should_match\" : 1}";
     private static final String TEMPLATE_MATCH = "{\"query_string\": {\n" +
         "        \"fields\": [\"%s\"],\n" +
         "        \"query\": \"%s\"\n" +

--- a/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2EsTest.java
+++ b/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2EsTest.java
@@ -93,7 +93,7 @@ class CswFilter2EsTest {
             fieldValues.add(field);
             query.set("fields", fieldValues);
         }
-        query.put("query", queryString == null ? "%s" : queryString);
+        query.put("query", queryString == null ? "{@}" : queryString);
 
         queryStringNode.set("query_string", query);
 


### PR DESCRIPTION
Fix Mapstore CSW request.

Only requests on full words works.

## Issue

The elasticsearch request is generated with content like : 
```
{
...
query: "%s",
...
query: "%my search%"
...
}
```

The line changed : `String jsonQuery = String.format(elasticSearchQuery, filterQueryString);` couldn't handle `%m` of 'my search' 

## Solution 

Replace all occurences of `"%s"` by the wanted complement of es request.

Double-quotes have been included to allow search beginning with s. Only a research with `%s` would be impacted I think.

## Curl request to test service :

```
// on local https://georchestra-127-0-1-1.traefik.me
curl 'https://georchestra-127-0-1-1.traefik.me/geonetwork/srv/fre/csw?service=CSW&version=2.0.2&request=' \
  -H 'authority: georchestra-127-0-1-1.traefik.me' \
  -H 'accept: application/json, text/plain, */*' \
  -H 'accept-language: en-US,en;q=0.9' \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/xml' \
  -H 'cookie: XSRF-TOKEN=a8308dae-7fc7-43e9-82cc-4c4ea2aa4860; serverTime=1704992499172; sessionExpiry=1704992499172; JSESSIONID=node01wq1jxvsxd6cyr121mwa37uxk0.node0' \
  -H 'origin: https://georchestra-127-0-1-1.traefik.me' \
  -H 'pragma: no-cache' \
  -H 'referer: https://georchestra-127-0-1-1.traefik.me/mapstore/' \
  -H 'sec-ch-ua: "Not_A Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "Linux"' \
  -H 'sec-fetch-dest: empty' \
  -H 'sec-fetch-mode: cors' \
  -H 'sec-fetch-site: same-origin' \
  -H 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36' \
  --data-raw $'<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:ows="http://www.opengis.net/ows" service="CSW" version="2.0.2" resultType="results" startPosition="1" maxRecords="4"> <csw:Query typeNames="csw:Record"> <csw:ElementSetName>full</csw:ElementSetName> <csw:Constraint version="1.1.0"> <ogc:Filter> <ogc:And>\n        <ogc:PropertyIsLike wildCard=\'%\' singleChar=\'_\' escapeChar=\'\\\'><ogc:PropertyName>csw:AnyText</ogc:PropertyName> <ogc:Literal>%sol%</ogc:Literal> </ogc:PropertyIsLike> \n        <ogc:Or>\n            <ogc:PropertyIsEqualTo>\n                <ogc:PropertyName>dc:type</ogc:PropertyName>\n                <ogc:Literal>dataset</ogc:Literal>\n            </ogc:PropertyIsEqualTo>\n            <ogc:PropertyIsEqualTo>\n                <ogc:PropertyName>dc:type</ogc:PropertyName>\n                <ogc:Literal>http://purl.org/dc/dcmitype/Dataset</ogc:Literal>\n            </ogc:PropertyIsEqualTo>\n       </ogc:Or>\n    </ogc:And> </ogc:Filter> </csw:Constraint> </csw:Query> </csw:GetRecords>' \
  --compressed
```

@juanluisrp If interested, it's a use case we've found today.