### PR TITLE
Add backport bot and remove push image from yml file

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,14 @@
+name: Backport
+
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    name: Backport closed pull request
+    steps:
+      - uses: syndesisio/backport-action@v1

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,14 +1,24 @@
-name: Backport
+name: Automatic backport action
 
 on:
-  pull_request:
-    types:
-      - closed
-      - labeled
+  pull_request_target:
+    types: ["labeled", "closed"]
 
 jobs:
   backport:
+    name: Backport PR
     runs-on: ubuntu-latest
-    name: Backport closed pull request
     steps:
-      - uses: syndesisio/backport-action@v1
+      - name: Backport Action
+        uses: sqren/backport-github-action@v9.3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          auto_backport_label_prefix: backport-to-
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log

--- a/.github/workflows/georchestra-gn4.yml
+++ b/.github/workflows/georchestra-gn4.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build:
+    if: "!startsWith(github.event.head_commit.message, '[skip ci] ')"
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -68,20 +69,3 @@ jobs:
         name: geonetwork.war
         path: web/target/geonetwork.war
 
-    - name: "Login onto docker-hub"
-      if: github.repository == 'georchestra/geonetwork' && github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/georchestra-gn4.2.x' && github.event_name != 'pull_request'
-      uses: docker/login-action@v1
-      with:
-        username: '${{ secrets.DOCKER_HUB_USERNAME }}'
-        password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
-
-    - name: "Pushing branch image to docker-hub"
-      if: github.repository == 'georchestra/geonetwork' && github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/georchestra-gn4.2.x' && github.event_name != 'pull_request'
-      run: |
-        docker push georchestra/geonetwork:${DOCKER_TAG}
-
-    - name: "Pushing latest image to docker-hub"
-      if: github.repository == 'georchestra/geonetwork' && github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/georchestra-gn4.2.x' && github.event_name != 'pull_request'
-      run: |
-        docker tag georchestra/geonetwork:${DOCKER_TAG} georchestra/geonetwork:latest
-        docker push georchestra/geonetwork:latest


### PR DESCRIPTION
Implementation of simple backport-bot. To use it, add a label with corresponding version.

Exemple on geOrchestra : [Source PR](https://github.com/georchestra/georchestra/pull/4145) (label `backport-to-23.0.x)`-> [Dest PR](https://github.com/georchestra/georchestra/pull/4148)

Also remove image pushing for Docker hub