### PR TITLE
logging configuration file should be taken from georchestra datadir

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/site/LogUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/site/LogUtils.java
@@ -79,9 +79,29 @@ public class LogUtils {
             setting = settingOpt.get();
         }
 
+
+        String loggingConfigurationPath;
+        try {
+            loggingConfigurationPath = (String) ApplicationContextHolder.get().getBean("loggingConfigurationPath");
+            CONFIG_LOG.info("Found loggingConfigurationPath='"+loggingConfigurationPath+"' in the bean configuration");
+        } catch (BeansException e) {
+            loggingConfigurationPath = null;
+        }
+
         // get log config from db settings
         String log4jProp = setting != null ? setting.getValue() : DEFAULT_LOG_FILE;
-        URL url = LogUtils.class.getResource("/" + log4jProp);
+        URL url ;
+
+        if (loggingConfigurationPath != null) {
+            try {
+                url = Paths.get(loggingConfigurationPath, log4jProp).toUri().toURL();
+            } catch (MalformedURLException e) {
+                url = LogUtils.class.getResource("/" + log4jProp);
+            }
+        } else {
+                url = LogUtils.class.getResource("/" + log4jProp);
+        }
+
         try {
             if (url != null) {
                 // refresh configuration


### PR DESCRIPTION
fixes #272

reinstated from 1ec55bea1, has been lost in fa284b7

should be backported to `georchestra-gn4.2.x-23.0.x` & `georchestra-gn4.2.x-rebase` branches