### PR TITLE
dont ship an extra version of groovy jar (fixes #267)

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -531,6 +531,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>gn-camelPeriodicProducer</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
that extra jar breaks geonetwork startup, cf https://github.com/georchestra/ansible/pull/125#issuecomment-1645748765

should be backported to `georchestra-gn4.2.x-23.0.x` & `georchestra-gn4.2.x-rebase` branches

thanks @pmauduit for the maven wizardry, as usual :)