### PR TITLE
Placeholder for ogc api features added as external resource

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
@@ -455,7 +455,8 @@
         "process": "onlinesrc-add",
         "fields": {
           "url": {
-            "isMultilingual": false
+            "isMultilingual": false,
+            "placeholder": "https://site.com/data/ogcapi/collections/{collectionId}/items"
           },
           "protocol": {
             "value": "OGC API Features",


### PR DESCRIPTION
When selecting `OGC API Features` on a 19115-3 template, it uses this new placeholder to indicate we should end it with `/items`.

To be added in `georchestra-gn4.2.x-rebase` and backported in `georchestra-gn4.2.x-23.0.x`.