### PR TITLE
Update backport to trigger on closed and automatically merge

### DIFF
--- a/.backport/.config.json
+++ b/.backport/.config.json
@@ -1,0 +1,3 @@
+{
+  "autoMerge": true
+}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -2,7 +2,7 @@ name: Automatic backport action
 
 on:
   pull_request_target:
-    types: ["labeled", "closed"]
+    types: ["closed"]
 
 jobs:
   backport:


### PR DESCRIPTION
Don't trigger on 'labeled' to avoid failed CI.

Automatically merge backported branches.