### PR TITLE
[feat] allow to open COG links in external viewer (#7387)

### DIFF
--- a/georchestra-migration/migration-dev-guide.md
+++ b/georchestra-migration/migration-dev-guide.md
@@ -62,7 +62,7 @@ All italic folder just have the `pom.xml` change.
 - *release*
 - schemas
   - `src/main/plugin/iso19115-3.2018`
-    - OGC API features and 3Dtiles added. Differences in files: 
+    - OGC API features, COG and 3Dtiles added. Differences in files:
       - `config/associated-panel/default.json`
       - `loc/eng/labels.xml`
       - `loc/fre/labels.xml`
@@ -70,7 +70,7 @@ All italic folder just have the `pom.xml` change.
       - `test/resources/metadata-for-editing-light.xml`
       - `test/resources/metadata-iso19139-for-editing.xml`
       - `src/main/plugin/iso19115-3.2018/config/associated-panel/default.json` : Keep OGC API - Features placeholder
-  - `src/main/plugin/iso19139/loc` : 3Dtiles added in labels.xml files.
+  - `src/main/plugin/iso19139/loc` : COG and 3Dtiles added in labels.xml files.
 - *schemas-test*
 - *sde*
 - services

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/labels.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/labels.xml
@@ -3933,6 +3933,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web
       </option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/labels.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/labels.xml
@@ -6358,6 +6358,7 @@ la non-évaluation</b>, dans le cadre de métadonnées INSPIRE
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ara/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ara/labels.xml
@@ -2193,6 +2193,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option show="-" value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/cat/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/cat/labels.xml
@@ -1875,6 +1875,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option value="OGC:CSW">OGC-CSW Servei de catàleg per a la Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Llenguatge de Marcat Geogràfic</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/chi/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/chi/labels.xml
@@ -2189,6 +2189,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option show="-" value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/dut/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/dut/labels.xml
@@ -1837,6 +1837,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option show="-" value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/labels.xml
@@ -2274,6 +2274,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fin/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fin/labels.xml
@@ -2158,6 +2158,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web
       </option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fre/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fre/labels.xml
@@ -4357,6 +4357,7 @@ la non-évaluation</b>, dans le cadre de métadonnées INSPIRE
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
@@ -2584,6 +2584,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option value="OGC:WMS-http-get-map">OGC-WMS Web Map Service</option>
       <option value="OGC:WFS-http-get-capabilities">OGC-WFS Web Feature Service</option>
       <option value="OGC:WCS-http-get-capabilities">OGC-WCS Web Coverage Service</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ita/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ita/labels.xml
@@ -2041,6 +2041,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web
       </option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/nor/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/nor/labels.xml
@@ -1973,6 +1973,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option show="-" value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/pol/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/pol/labels.xml
@@ -1645,6 +1645,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/labels.xml
@@ -2129,6 +2129,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option show="-" value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/rus/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/rus/labels.xml
@@ -2223,6 +2223,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option show="-" value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option show="-" value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option show="-" value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/slo/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/slo/labels.xml
@@ -1754,6 +1754,7 @@ presnosť / vertikálna -</option>
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/spa/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/spa/labels.xml
@@ -1945,6 +1945,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option value="OGC:CSW">OGC-CSW Servicio de catálogo para la Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Lenguaje de Marcado Geográfico</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/tur/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/tur/labels.xml
@@ -1785,6 +1785,7 @@
       <option value="OGC API - Maps">OGC API - Maps</option>
       <option value="OGC API - Records">OGC API - Records</option>
       <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
       <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web</option>
       <option value="OGC:KML">OGC-KML Keyhole Markup Language</option>
       <option value="OGC:GML">OGC-GML Geography Markup Language</option>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -79,7 +79,7 @@
           return r.mimeType;
         } else if (r.protocol && r.protocol.indexOf("WWW:DOWNLOAD:") >= 0) {
           return r.protocol.replace("WWW:DOWNLOAD:", "");
-        } else if (mainType.match(/W([MCF]|MT)S.*|3DTILES|ESRI:REST/) != null) {
+        } else if (mainType.match(/W([MCF]|MT)S.*|3DTILES|COG|ESRI:REST/) != null) {
           return mainType.replace("SERVICE", "");
         } else if (mainType.match(/KML|GPX/) != null) {
           return mainType;
@@ -127,6 +127,8 @@
       var addWMSToMap =
         gnViewerSettings.resultviewFns && gnViewerSettings.resultviewFns.addMdLayerToMap;
       var add3dTilesToMap =
+        gnViewerSettings.resultviewFns && gnViewerSettings.resultviewFns.addMdLayerToMap;
+      var addCogeoToMap =
         gnViewerSettings.resultviewFns && gnViewerSettings.resultviewFns.addMdLayerToMap;
       var addEsriRestToMap =
         gnViewerSettings.resultviewFns && gnViewerSettings.resultviewFns.addMdLayerToMap;
@@ -285,6 +287,11 @@
           iconClass: "fa-globe",
           label: "addToMap",
           action: add3dTilesToMap
+        },
+        COG: {
+          iconClass: "fa-globe",
+          label: "addToMap",
+          action: addCogeoToMap
         },
         TMS: {
           iconClass: "fa-globe",
@@ -517,6 +524,8 @@
             return "WMTS";
           } else if (protocolOrType.match(/3dtiles/i)) {
             return "3DTILES";
+          } else if (protocolOrType.match(/cog/i)) {
+            return "COG";
           } else if (protocolOrType.match(/tms/i)) {
             return "TMS";
           } else if (protocolOrType.match(/wfs/i)) {

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1312,6 +1312,7 @@
             layers: [
               "OGC:WMS",
               "OGC:3DTILES",
+              "OGC:COG",
               "OGC:WMTS",
               "OGC:WMS-1.1.1-http-get-map",
               "OGC:WMS-1.3.0-http-get-map",

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -378,6 +378,7 @@
     "layerNotAvailableInMapProj": "The service does not provide the layer in the map projection '{{proj}}'. The layer will be added to the map but may not be displayed properly.",
     "layerCRSNotFound": "The layer does not provide coordinate reference system information. This may be related to a WMS version lower than 1.3.0.",
     "layerTileLoadError": "Something went wrong while loading tile <a href='{{url}}' target='_blank'>'{{url | limitTo: 30}} ...'</a> for layer '{{layer}}'.",
+    "layerProtocolNotSupported": "The following protocol is not supported yet in the map viewer: {{type}}",
     "getCapFailure":"The WMS getCapabilities request failed",
     "standards": "Metadata standard",
     "documentStandard": "Metadata standard",

--- a/web-ui/src/main/resources/catalog/style/gn_icons.less
+++ b/web-ui/src/main/resources/catalog/style/gn_icons.less
@@ -280,6 +280,8 @@
 .gn-icontype-wps,
 .gn-icontype-wcs,
 .gn-icontype-atom,
+.gn-icontype-3dtiles,
+.gn-icontype-cog,
 .gn-icontype-esri-rest,
 .gn-icontype-wfs {
   background-color: @btn-success-bg !important;

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -169,6 +169,7 @@
     "gnFacetSorter",
     "gnExternalViewer",
     "gnUrlUtils",
+    "gnAlertService",
     function (
       $scope,
       $location,
@@ -191,7 +192,8 @@
       gnESFacet,
       gnFacetSorter,
       gnExternalViewer,
-      gnUrlUtils
+      gnUrlUtils,
+      gnAlertService
     ) {
       var viewerMap = gnSearchSettings.viewerMap;
       var searchMap = gnSearchSettings.searchMap;
@@ -353,16 +355,23 @@
       });
 
       function buildAddToMapConfig(link, md) {
+        var type = "wms";
+        if (link.protocol.indexOf("WMTS") > -1) {
+          type = "wmts";
+        } else if (
+          link.protocol === "ESRI:REST" ||
+          link.protocol.startsWith("ESRI REST")
+        ) {
+          type = "esrirest";
+        } else if (link.protocol === "OGC:3DTILES") {
+          type = "3dtiles";
+        } else if (link.protocol === "OGC:COG") {
+          type = "cog";
+        }
+
         var config = {
           uuid: md ? md.uuid : null,
-          type:
-            link.protocol.indexOf("WMTS") > -1
-              ? "wmts"
-              : link.protocol == "ESRI:REST" || link.protocol.startsWith("ESRI REST")
-              ? "esrirest"
-              : link.protocol == "OGC:3DTILES"
-              ? "3dtiles"
-              : "wms",
+          type,
           url: $filter("gnLocalized")(link.url) || link.url
         };
 
@@ -412,6 +421,19 @@
           );
           return;
         }
+
+        // no support for COG or 3DTiles for now
+        if (config.type === "cog" || config.type === "3dtiles") {
+          gnAlertService.addAlert({
+            msg: $translate.instant("layerProtocolNotSupported", {
+              type: link.protocol
+            }),
+            delay: 20000,
+            type: "warning"
+          });
+          return;
+        }
+
         return config;
       }
 
@@ -419,20 +441,28 @@
         addMdLayerToMap: function (link, md) {
           // This is probably only a service
           // Open the add service layer tab
+          var config = buildAddToMapConfig(link, md);
+          if (!config) {
+            return;
+          }
           $location.path("map").search({
-            add: encodeURIComponent(angular.toJson([buildAddToMapConfig(link, md)]))
+            add: encodeURIComponent(angular.toJson([config]))
           });
-          return;
         },
         addAllMdLayersToMap: function (layers, md) {
-          var config = [];
-          angular.forEach(layers, function (layer) {
-            config.push(buildAddToMapConfig(layer, md));
-          });
+          var config = layers
+            .map(function (layer) {
+              return buildAddToMapConfig(layer, md);
+            })
+            .filter(function (config) {
+              return !!config;
+            });
+          if (config.length === 0) {
+            return;
+          }
           $location.path("map").search({
             add: encodeURIComponent(angular.toJson(config))
           });
-          return;
         },
         loadMap: function (map, md) {
           gnOwsContextService.loadContextFromUrl(map.url, viewerMap);


### PR DESCRIPTION
* add OGC:COG to possible values for gmd:protocol

* add support to open OGC:COG links in the external viewer

* show an alert saying COG/3DTiles is not supported yet

This will also avoid switching to the viewer if no layer with supported protocol is found

---------

**Geochestra/geonetwork checklist**
<!--- In order to ease future geonetwork migration : -->

- [x] PR only involves cherry picked commits from upstream. (geonetwork/core-geonetwork#7387)
- [ ] PR contains custom code which will be soon available in a release on upstream and can be overrided. Mention core-geonetwork version if possible.
- [ ] PR contains custom georchestra code, which need to be verified in future migration.


supersedes #252 which targeted a removed branch, and for some reason it seems one can't edit a target branch anymore in existing PRs

