### PR TITLE
[CI] Fix GHA with removing cache for setup java

### DIFF
--- a/.github/workflows/georchestra-gn4.yml
+++ b/.github/workflows/georchestra-gn4.yml
@@ -32,7 +32,6 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
-        cache: 'maven'
 
     - name: "Installing the geOrchestra root pom"
       run: |


### PR DESCRIPTION
We keep v2 as we need old toolchains (java 8)

**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

- [ ] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [ ] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [ ] I have properly filled the [migration-helper-changelog.md](..%2Fgeorchestra-migration%2Fmigration-helper-changelog.md) file.

