### PR TITLE
fix: add showMapInfacet inside config

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -920,6 +920,7 @@ INSERT INTO settings_ui VALUES ('srv', '{
       },
       "fluidEditorLayout": true,
       "isFilterTagsDisplayed": false,
+      "showMapInFacet": false,
       "isUserRecordsOnly": false,
       "minUserProfileToCreateTemplate": ""
     },


### PR DESCRIPTION
Adds showMapInFacet in default config in order to display it by default.

We should also rebase this default config to the full config of gn.

**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

- [ ] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [x] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [x] I have properly filled the [migration-helper-changelog.md](..%2Fgeorchestra-migration%2Fmigration-helper-changelog.md) file.

