### PR TITLE
reenable xlinks for contacts

### DIFF
--- a/georchestra-migration/migration-dev-guide.md
+++ b/georchestra-migration/migration-dev-guide.md
@@ -71,6 +71,7 @@ All italic folder just have the `pom.xml` change.
       - `test/resources/metadata-iso19139-for-editing.xml`
       - `src/main/plugin/iso19115-3.2018/config/associated-panel/default.json` : Keep OGC API - Features placeholder
   - `src/main/plugin/iso19139/loc` : COG and 3Dtiles added in labels.xml files.
+  - `iso19139/layout/config-editor.xml`: xlinks for contacts reenabled
 - *schemas-test*
 - *sde*
 - services

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -201,7 +201,7 @@
         data-search-action="true"
         data-popup-action="true"
         data-template-type="contact"
-        data-insert-modes=""
+        data-insert-modes="text,xlink"
         data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
     </for>
     <for name="gmd:pointOfContact" addDirective="data-gn-directory-entry-selector">
@@ -210,7 +210,7 @@
         data-search-action="true"
         data-popup-action="true"
         data-template-type="contact"
-        data-insert-modes=""
+        data-insert-modes="text,xlink"
         data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
     </for>
     <for name="gmd:distributorContact" addDirective="data-gn-directory-entry-selector">
@@ -219,7 +219,7 @@
         data-search-action="true"
         data-popup-action="true"
         data-template-type="contact"
-        data-insert-modes=""
+        data-insert-modes="text,xlink"
         data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
     </for>
     <for name="gmd:processor" addDirective="data-gn-directory-entry-selector">
@@ -228,7 +228,7 @@
         data-search-action="true"
         data-popup-action="true"
         data-template-type="contact"
-        data-insert-modes=""
+        data-insert-modes="text,xlink"
         data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
     </for>
     <for name="gmd:citedResponsibleParty" addDirective="data-gn-directory-entry-selector">
@@ -237,7 +237,7 @@
         data-search-action="true"
         data-popup-action="true"
         data-template-type="contact"
-        data-insert-modes=""
+        data-insert-modes="text,xlink"
         data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
     </for>
     <for name="gmd:report" addDirective="data-gn-directory-entry-selector">


### PR DESCRIPTION
cf geonetwork/core-geonetwork#7941 - with this i'm now able to use xlinks for contacts, which got disabled with the 4.2 upgrade.

![image](https://github.com/georchestra/geonetwork/assets/3421760/6a952c22-7fce-4d82-9752-5df91a049cfc)

i'll also do a pr on the geonetwork_minimal_datadir repo.

**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

- [ ] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [x] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [x] I have properly filled the [migration-helper-changelog.md](..%2Fgeorchestra-migration%2Fmigration-helper-changelog.md) file.

