### PR TITLE
docker/jetty - removes javax.mail library provided by the docker imag…

### DIFF
--- a/web/src/docker/Dockerfile
+++ b/web/src/docker/Dockerfile
@@ -14,6 +14,9 @@ RUN chown jetty:jetty /docker-entrypoint.d
 RUN mkdir -p /mnt/geonetwork_datadir && \
     chown jetty:jetty /mnt/geonetwork_datadir
 
+# Removes extra javax.mail library provided by Jetty
+RUN rm -rf /usr/local/jetty/lib/mail
+
 # Restore jetty user
 USER jetty
 


### PR DESCRIPTION
…e (georchestra/georchestra#4233)

**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

- [ ] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [x] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [x] I have properly filled the [migration-helper-changelog.md](../georchestra-migration/migration-helper-changelog.md) file.

