### PR TITLE
Override only desc and name on role based sync

### DIFF
--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/AbstractGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/AbstractGroupSynchronizer.java
@@ -155,15 +155,19 @@ abstract class AbstractGroupSynchronizer implements GroupSynchronizer {
             updateLabelTranslations(canonical, group);
         }
 
+        link = externalGroupLinks.save(getSyncElements(group, canonical, link));
+        assert link.isUpToDateWith(canonical);
+
+        return link;
+    }
+
+    protected GroupLink getSyncElements(Group group, CanonicalGroup canonical, GroupLink link) {
         logoUpdater.synchronize(canonical.getId(), group);
         group.setName(canonical.getName());
         group.setDescription(canonical.getDescription());
         group.setWebsite(canonical.getLinkage());
         group.setEmail(canonical.getMail());
         link.setCanonical(canonical);
-        link = externalGroupLinks.save(link);
-        assert link.isUpToDateWith(canonical);
-
         return link;
     }
 

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolesBasedGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolesBasedGroupSynchronizer.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.fao.geonet.domain.Group;
 import org.geonetwork.security.external.configuration.ExternalizedSecurityProperties;
 import org.geonetwork.security.external.model.CanonicalGroup;
 import org.geonetwork.security.external.model.CanonicalUser;
@@ -124,4 +125,11 @@ public class RolesBasedGroupSynchronizer extends AbstractGroupSynchronizer {
         return doesNotMatchesGeorchestraDefaultRoleNameFilter(role.getName());
     }
 
+    @Override
+    protected GroupLink getSyncElements(Group group, CanonicalGroup canonical, GroupLink link) {
+        group.setName(canonical.getName());
+        group.setDescription(canonical.getDescription());
+        link.setCanonical(canonical);
+        return link;
+    }
 }

--- a/georchestra-integration/externalized-accounts/src/test/java/org/geonetwork/security/external/integration/IntegrationTestSupport.java
+++ b/georchestra-integration/externalized-accounts/src/test/java/org/geonetwork/security/external/integration/IntegrationTestSupport.java
@@ -186,7 +186,9 @@ public class IntegrationTestSupport extends ExternalResource {
     public void assertGroup(CanonicalGroup expected, Group actual) {
         assertEquals(expected.getName(), actual.getName());
         assertEquals(expected.getDescription(), actual.getDescription());
-        assertEquals(expected.getLinkage(), actual.getWebsite());
+        if (!getConfig().getSyncMode().equals(GroupSyncMode.roles)) {
+            assertEquals(expected.getLinkage(), actual.getWebsite());
+        }
     }
 
     public void addGeonetworkGroup(CanonicalGroup g) {


### PR DESCRIPTION
Used to override only name and description when group sync is set to roles.

It avoids to override/delete information set in geonetwork like image, email and website.

**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

- [ ] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [x] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [x] I have properly filled the [migration-helper-changelog.md](../georchestra-migration/migration-helper-changelog.md) file.

