### PR TITLE
domain - set some columns to arbitrary length (TEXT type)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,5 +4,5 @@
 - [ ] PR only involves cherry-picked commits from upstream.
 - [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
 - [ ] PR contains custom geOrchestra code, which need to be verified during future migrations.
-  -  [ ] I have properly filled the [migration-helper-changelog.md](../georchestra-migration/migration-helper-changelog.md) file.
+  -  [ ] I have properly filled the [migration-dev-guide.md](/georchestra/geonetwork/blob/georchestra-gn4.4.x/georchestra-migration/migration-dev-guide.md) file.
 

--- a/.github/workflows/georchestra-gn4.yml
+++ b/.github/workflows/georchestra-gn4.yml
@@ -61,4 +61,3 @@ jobs:
       with:
         name: geonetwork.war
         path: web/target/geonetwork.war
-

--- a/domain/src/main/java/org/fao/geonet/domain/Group.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Group.java
@@ -31,28 +31,8 @@ import java.util.Map;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.persistence.Access;
-import javax.persistence.AccessType;
-import javax.persistence.Cacheable;
-import javax.persistence.CascadeType;
-import javax.persistence.CollectionTable;
-import javax.persistence.Column;
-import javax.persistence.Convert;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.MapKeyColumn;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
-import javax.persistence.Transient;
+import javax.persistence.*;
+
 import org.fao.geonet.domain.converter.BooleanToYNConverter;
 
 import org.fao.geonet.entitylistener.GroupEntityListenerManager;
@@ -141,7 +121,7 @@ public class Group extends Localized implements Serializable {
      *
      * @return the description.
      */
-    @Column(length = 255)
+    @Column(columnDefinition = "TEXT")
     public String getDescription() {
         return _description;
     }
@@ -245,6 +225,7 @@ public class Group extends Localized implements Serializable {
      * @return the filename of the logo or null if there is no logo associated with this group.
      */
     @Nullable
+    @Column(columnDefinition = "TEXT")
     public String getLogo() {
         return logo;
     }

--- a/domain/src/main/java/org/fao/geonet/domain/external/ExternalGroupLink.java
+++ b/domain/src/main/java/org/fao/geonet/domain/external/ExternalGroupLink.java
@@ -20,12 +20,7 @@ package org.fao.geonet.domain.external;
 
 import java.util.Objects;
 
-import javax.persistence.Access;
-import javax.persistence.AccessType;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.fao.geonet.domain.Group;
 
@@ -55,6 +50,7 @@ public class ExternalGroupLink {
     private String externalId;
     private GroupSyncMode origin;
     private String name;
+
     private String description;
     private String linkage;
     private String lastUpdated;
@@ -108,6 +104,12 @@ public class ExternalGroupLink {
         return this;
     }
 
+    /**
+     * Note: this is not portable, as the TEXT definition does not
+     * exist on all DBMS. But considering geOrchestra, we are supposed
+     * to rely on a PostGreSQL server.
+     */
+    @Column(columnDefinition = "TEXT")
     public String getDescription() {
         return description;
     }

--- a/georchestra-migration/migration-dev-guide.md
+++ b/georchestra-migration/migration-dev-guide.md
@@ -1,6 +1,6 @@
 # Geonetwork migration in Georchestra
 
-This document aims to help simplify future migration for geonetwork in Georchestra. 
+This document aims to help simplify future migration for geonetwork in Georchestra.
 
 ## Upgrade Process
 
@@ -17,14 +17,12 @@ A more detailed guide is available in [upgrade_geonetwork.md](upgrade_geonetwork
 
 ## Georchestra custom implementations
 
-### Georchestra 4.2.7 and Gn 4.2.7
-
 All versions in `pom.xml` files must be updated. E.g. for this version `4.4.5-georchestra`.
 All italic folder just have the `pom.xml` change.
 
 - .github
   - workflows `linux.yml` `mvn-dep-tree.yml` `sonarcloud.yml` `dependabot.yml` are deleted. Only `georchestra-gn4.yml` is used
-- *cachingxslt* 
+- *cachingxslt*
 - common
   - `ZipUtilTest.java` : In `assertExampleZip` method, assertions which are supposed check folders must check with trailing slash too.
 - core
@@ -36,17 +34,18 @@ All italic folder just have the `pom.xml` change.
   - `CswFilter2Es.java` : Keep `{@}` instead of `%s` until it is fixed upstream (not supporting some CSW request)
   - `CswFilter2EsTest.java` : Keep `{@}` instead of `%s`
   - `SearchController.java` : Keep `{@}` instead of `%s` with StringUtils.replace
-- **docker** 
+- **docker**
   - Mandatory, get everything from geOrchestra
 - *docs*
 - *doi*
 - domain
-  - ExternalGroupLink.java : get file from geOrchestra
-  - ExternalUserLink.java : get file from geOrchestra
+  - `ExternalGroupLink.java` : get file from geOrchestra
+  - `ExternalUserLink.java` : get file from geOrchestra
+  - `Group.java` : set column definition to `TEXT` (which is PostGreSQL specific) on `description` and `logo`
 - *es*
 - *estest*
 - *events*
-- **georchestra-integration** 
+- **georchestra-integration**
   - Mandatory, get everything from geOrchestra
 - *harvesters*
 - *healthmonitor*
@@ -99,7 +98,7 @@ All italic folder just have the `pom.xml` change.
   - `src/main/resources/catalog/views/georchestra/`: Get files from georchestra
 - *workers*
 - *wro4j*
-- .gitignore 
+- .gitignore
   - add idea and settings to it
 - pom.xml  
   - Add georchestra-integration module, set db-type
@@ -111,4 +110,3 @@ All italic folder just have the `pom.xml` change.
 A branch has been created from core-geonetwork 4.2.7 tag and merged into `georchestra-gn4.2.x`.
 All conflicts files have been resolved with taking gn changes and not grochestra's one.
 Then changes have been reimplemented.
-


### PR DESCRIPTION
In some cases we would need more than the default length for string (255chars), e.g. when using large logos or very long descriptions for our groups in the Console. Using a TEXT type sounds more appropriate than a VARCHAR which would require to raise the max number each time the limit is reached.

As indicated in a comment, this is not portable, but works with postgresql which is the de-facto standard in geOrchestra ? Rapidly checking, it looks like Oracle also supports it.

Tests: runtime tested.


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [x] *Build documentation* provided for development instructions in `README.md` files
- [x] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

- [ ] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [x] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [ ] I have properly filled the [migration-helper-changelog.md](../georchestra-migration/migration-helper-changelog.md) file.
