### PR TITLE
Fix user synchronizer if only reviewer and not both

### DIFF
--- a/.github/workflows/georchestra-gn4.yml
+++ b/.github/workflows/georchestra-gn4.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: "publish the webapp as artifact"
       if: github.repository == 'georchestra/geonetwork' && github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/georchestra-gn4.2.x' && github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: geonetwork.war
         path: web/target/geonetwork.war

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/UserSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/UserSynchronizer.java
@@ -147,12 +147,22 @@ class UserSynchronizer {
     }
 
     private List<UserGroup> resolveNewPrivileges(User user, List<Privilege> actual) {
-        List<Privilege> editors = actual.stream().filter(privilege -> privilege.getProfile() == Profile.Reviewer)//
-                .map(privilege -> {
+
+        List<Privilege> editors = actual.stream().filter(privilege -> privilege.getProfile() == Profile.Reviewer || privilege.getProfile() == Profile.Editor)
+            // group by geonetwork group
+            .collect(Collectors.groupingBy(Privilege::getGroup))//
+            .values().stream()//
+            // check if both reviewer and editor are present for the same group and profile is only reviewer
+            .filter(privileges -> privileges.size() == 1 && privileges.get(0).getProfile() == Profile.Reviewer)
+            // get first privilege (reviewer)
+            .map(privileges -> privileges.get(0))
+            // create a new privilege with editor profile
+            .map(privilege -> {
                     log.debug("User {} is a reviewer of group {}", user.getUsername(),
                         privilege.getGroup().getName());
                     return new Privilege(privilege.getGroup(), Profile.Editor);
                 }).collect(Collectors.toList());
+        //Combine all the privileges
         editors.addAll(actual);
 
         return editors.stream()//

--- a/georchestra-integration/externalized-accounts/src/test/java/org/geonetwork/security/external/integration/IntegrationTestSupport.java
+++ b/georchestra-integration/externalized-accounts/src/test/java/org/geonetwork/security/external/integration/IntegrationTestSupport.java
@@ -143,14 +143,14 @@ public class IntegrationTestSupport extends ExternalResource {
     public UserGroup assertGroup(User user, CanonicalGroup belongsTo) {
         GroupLink link = assertGroupLink(belongsTo);
         Group group = link.getGeonetworkGroup();
-        Map<Integer, UserGroup> byGroupId = gnUserGroupRepository.findAll(UserGroupSpecs.hasUserId(user.getId()))
-                .stream().collect(Collectors.toMap(ug -> ug.getGroup().getId(), Function.identity()));
+        Map<Integer, List<UserGroup>> byGroupId = gnUserGroupRepository.findAll(UserGroupSpecs.hasUserId(user.getId()))
+                .stream().collect(Collectors.groupingBy(ug -> ug.getGroup().getId()));
 
-        UserGroup userGroup = byGroupId.get(group.getId());
+        UserGroup userGroup = byGroupId.get(group.getId()).get(0);
         String msg = String.format("User '%s': link to group %s not found. Got: %s", user.getUsername(),
                 group.getName(),
                 user.getUsername() + " user's link to group " + group.getName() + " not found: " + byGroupId.values()
-                        .stream().map(UserGroup::getGroup).map(Group::getName).collect(Collectors.joining(",")));
+                        .stream().map(us -> us.get(0)).map(UserGroup::getGroup).map(Group::getName).collect(Collectors.joining(",")));
         assertNotNull(msg, userGroup);
         return userGroup;
     }


### PR DESCRIPTION
**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

- [ ] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [x] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [x] I have properly filled the [migration-helper-changelog.md](../georchestra-migration/migration-helper-changelog.md) file.

