### PR TITLE
fix : csw server not ignoring failures

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
@@ -53,10 +53,7 @@ import org.fao.geonet.kernel.search.EsFilterBuilder;
 import org.fao.geonet.kernel.search.EsSearchManager;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
-import org.jdom.Attribute;
-import org.jdom.Content;
-import org.jdom.Element;
-import org.jdom.Namespace;
+import org.jdom.*;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.nio.file.Files;
@@ -510,16 +507,20 @@ public class SearchController {
                 AbstractMetadata metadata = metadataUtils.findOne(mdId);
 
                 String displayLanguage = context.getLanguage();
+                try {
                 // The query to retrieve GetRecords, filters by portal. No need to re-check again when retrieving each metadata.
-                Element resultMD = retrieveMetadata(context, metadata.getId() + "",
-                    setName, outSchema, elemNames, typeName, resultType, strategy, displayLanguage, false);
+                    Element resultMD = retrieveMetadata(context, metadata.getId() + "",
+                        setName, outSchema, elemNames, typeName, resultType, strategy, displayLanguage, false);
 
-                if (resultMD != null) {
-                    if (resultType == ResultType.RESULTS) {
-                        results.addContent(resultMD);
+                    if (resultMD != null) {
+                        if (resultType == ResultType.RESULTS) {
+                            results.addContent(resultMD);
+                        }
+
+                        counter++;
                     }
-
-                    counter++;
+                } catch (InvalidParameterValueEx e) {
+                    results.addContent(new Comment(e.getMessage()));
                 }
 
             }

--- a/georchestra-migration/migration-dev-guide.md
+++ b/georchestra-migration/migration-dev-guide.md
@@ -33,7 +33,7 @@ All italic folder just have the `pom.xml` change.
 - csw-server
   - `CswFilter2Es.java` : Keep `{@}` instead of `%s` until it is fixed upstream (not supporting some CSW request)
   - `CswFilter2EsTest.java` : Keep `{@}` instead of `%s`
-  - `SearchController.java` : Keep `{@}` instead of `%s` with StringUtils.replace
+  - `SearchController.java` : Keep `{@}` instead of `%s` with StringUtils.replace, try/catch around Element resultMD, to avoid csw server to crash [issue core-gn 6940](https://github.com/geonetwork/core-geonetwork/issues/6940)
 - **docker**
   - Mandatory, get everything from geOrchestra
 - *docs*


### PR DESCRIPTION
Solves errors in csw server crashing when schema hasn't requested transformations.

Now display in response  : 
```xml
<?xml version="1.0" encoding="UTF-8"?>
<csw:GetRecordsResponse
	xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
	<csw:SearchStatus timestamp="2024-12-18T10:25:10.920103Z" />
	<csw:SearchResults numberOfRecordsMatched="1" numberOfRecordsReturned="0" elementSet="brief" nextRecord="1">
		<!--OutputSchema 'gmd' not supported for metadata with '100' (iso19110).
Corresponding XSL transformation 'gmd-brief.xsl' does not exist for this schema.
The record will not be returned in response.-->
	</csw:SearchResults>
</csw:GetRecordsResponse>

```

**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

- [ ] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [x] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [x] I have properly filled the [migration-dev-guide.md](/georchestra/geonetwork/blob/georchestra-gn4.4.x/georchestra-migration/migration-dev-guide.md) file.

