### PR TITLE
FIx importer when md is already validated

### DIFF
--- a/domain/src/main/java/org/fao/geonet/repository/MetadataValidationRepositoryCustom.java
+++ b/domain/src/main/java/org/fao/geonet/repository/MetadataValidationRepositoryCustom.java
@@ -51,7 +51,7 @@ public interface MetadataValidationRepositoryCustom {
      * @param metadataId the id of the metadata.
      * @return the number of rows deleted
      */
-    @Modifying(clearAutomatically=true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Transactional
     @Query(value="DELETE FROM MetadataValidation v where v.id.metadataId = ?1 AND valtype != 'inspire'")
     int deleteAllInternalValidationById_MetadataId(Integer metadataId);


### PR DESCRIPTION
In 4.2.8 (georchestra 24) we couldn't update with importer a matadata which has already been validated.

Steps to reproduce :
import a metadata and validate it.
Download xml and change title
Re-import with override
Title hasn't changed.

**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

- [ ] PR only involves cherry-picked commits from upstream.
- [x] PR contains custom code which will soon be available in an upstream release and can be overriden => 4.4.4
- [ ] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [ ] I have properly filled the [migration-dev-guide.md](/georchestra/geonetwork/blob/georchestra-gn4.4.x/georchestra-migration/migration-dev-guide.md) file.

