### PR TITLE
Set georchestra/geonetwork as independant build

### DIFF
--- a/.github/workflows/georchestra-gn4.yml
+++ b/.github/workflows/georchestra-gn4.yml
@@ -55,6 +55,26 @@ jobs:
     - name: "run tests"
       run: mvn verify -Pit
 
+    - name: "Run Georchestra Integration Tests"
+      working-directory: geonetwork/georchestra-integration/
+      run: mvn verify -ntp -Dadditionalparam=-Xdoclint:none
+
+    - name: "Build GeoNetwork docker image"
+      if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]'
+      run: |
+        cd geonetwork/web
+        mvn package docker:build -Pdocker -DdockerImageName=georchestra/geonetwork -DdockerImageTags=${{ steps.version.outputs.VERSION }},latest -DskipTests -ntp
+    - name: "Logging in docker.io"
+      uses: azure/docker-login@v1
+      if: github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
+      with:
+        username: '${{ secrets.DOCKER_HUB_USERNAME }}'
+        password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
+
+    - name: "Pushing latest to docker.io"
+      if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/georchestra' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
+      run: |
+        docker push georchestra/geonetwork:latest
     - name: "publish the webapp as artifact"
       if: github.repository == 'georchestra/geonetwork' && github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/georchestra-gn4.2.x' && github.event_name != 'pull_request'
       uses: actions/upload-artifact@v4

--- a/georchestra-migration/migration-dev-guide.md
+++ b/georchestra-migration/migration-dev-guide.md
@@ -101,7 +101,7 @@ All italic folder just have the `pom.xml` change.
 - .gitignore
   - add idea and settings to it
 - pom.xml  
-  - Add georchestra-integration module, set db-type
+  - Add georchestra-integration module, set db-type, and keep io.fabric docker plugin
 
 ## Process used
 

--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,11 @@
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>3.4.1</version>
         </plugin>
+        <plugin>
+          <groupId>io.fabric8</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>0.45.1</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

- [ ] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [x] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [x] I have properly filled the [migration-dev-guide.md](/georchestra/geonetwork/blob/georchestra-gn4.4.x/georchestra-migration/migration-dev-guide.md) file.

