### PR TITLE
drop corresponding records from metadataStatus when deleting a metadata 

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -304,6 +304,7 @@ public class BaseMetadataManager implements IMetadataManager {
         int intId = Integer.parseInt(id);
         metadataRatingByIpRepository.deleteAllById_MetadataId(intId);
         metadataValidationRepository.deleteAllById_MetadataId(intId);
+        metadataStatusRepository.deleteAllById_MetadataId(intId);
         userSavedSelectionRepository.deleteAllByUuid(metadataUtils.getMetadataUuid(id));
 
         // Logical delete for metadata file uploads


### PR DESCRIPTION
**geOrchestra/geonetwork checklist**
cf geonetwork/core-geonetwork#8693

it might also be needed on 4.4, dont have an instance to test, but to check one can do
```
select * from metadatastatus where metadataid not in (select id from metadata);
```
if there's some records, then that's leftovers from deleted metadatas.

- [x] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [ ] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [ ] I have properly filled the [migration-dev-guide.md](/georchestra/geonetwork/blob/georchestra-gn4.4.x/georchestra-migration/migration-dev-guide.md) file.

