### PR TITLE
fix: Preauth role based sync was trying to sync with ROLE_

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,5 @@ What does this PR do?
 - [ ] PR only involves cherry-picked commits from upstream.
 - [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
 - [ ] PR contains custom geOrchestra code, which need to be verified during future migrations.
-  -  [ ] I have properly filled the [migration-dev-guide.md](/georchestra/geonetwork/blob/georchestra-gn4.4.x/georchestra-migration/migration-dev-guide.md) file.
+  -  [ ] I have properly filled the [migration-dev-guide.md](/georchestra/geonetwork/blob/georchestra-gn4.4.x/georchestra-migration/migration-dev-guide.md) file, or it is already filled.
 

--- a/georchestra-integration/georchestra-authnz/src/main/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilter.java
+++ b/georchestra-integration/georchestra-authnz/src/main/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilter.java
@@ -24,8 +24,10 @@ import static org.georchestra.commons.security.SecurityHeaders.SEC_PROXY;
 import javax.servlet.http.HttpServletRequest;
 
 import org.fao.geonet.domain.User;
+import org.geonetwork.security.external.configuration.ExternalizedSecurityProperties;
 import org.geonetwork.security.external.integration.AccountsReconcilingService;
 import org.geonetwork.security.external.model.CanonicalUser;
+import org.geonetwork.security.external.model.GroupSyncMode;
 import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.config.security.GeorchestraSecurityProxyAuthenticationFilter;
 import org.georchestra.config.security.GeorchestraUserDetails;
@@ -63,6 +65,8 @@ public class GeorchestraPreAuthenticationFilter extends AbstractPreAuthenticated
      */
     private @Autowired AccountsReconcilingService userLinkService;
 
+    private @Autowired ExternalizedSecurityProperties configProps;
+
     private @Autowired CanonicalModelMapper modelMapper;
 
     public GeorchestraPreAuthenticationFilter() {
@@ -84,14 +88,14 @@ public class GeorchestraPreAuthenticationFilter extends AbstractPreAuthenticated
         final GeorchestraUser authenticatedUser = auth.getUser();
         final boolean isFullyAuthorized = null != authenticatedUser.getLastUpdated();
         User user;
-
+        if (configProps.getSyncMode() == GroupSyncMode.roles) {
+            authenticatedUser.setRoles(
+                authenticatedUser.getRoles().stream()
+                    .map(role -> role.replaceAll("^ROLE_", ""))
+                    .collect(Collectors.toList()));
+        }
         if (isFullyAuthorized) {// sec-user provided full user representation as JSON payload
             checkMandatoryProperties(auth.getUser());
-            // convert roles without the ROLE_ prefix
-            authenticatedUser.setRoles(
-                    authenticatedUser.getRoles().stream()
-                            .map(role -> role.replaceAll("^ROLE_", ""))
-                            .collect(Collectors.toList()));
             final CanonicalUser canonicalizedUser = modelMapper.toCanonical(authenticatedUser);
             user = userLinkService//
                     .findUpToDateUser(canonicalizedUser)//

--- a/georchestra-integration/georchestra-authnz/src/main/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilter.java
+++ b/georchestra-integration/georchestra-authnz/src/main/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilter.java
@@ -39,6 +39,8 @@ import org.springframework.security.web.authentication.preauth.AbstractPreAuthen
 
 import com.google.common.annotations.VisibleForTesting;
 
+import java.util.stream.Collectors;
+
 /**
  * Pre-auth filter that gets the credentials as a {@link GeorchestraUser} from a
  * {@link GeorchestraSecurityProxyAuthenticationFilter} using composition, and
@@ -85,6 +87,11 @@ public class GeorchestraPreAuthenticationFilter extends AbstractPreAuthenticated
 
         if (isFullyAuthorized) {// sec-user provided full user representation as JSON payload
             checkMandatoryProperties(auth.getUser());
+            // convert roles without the ROLE_ prefix
+            authenticatedUser.setRoles(
+                    authenticatedUser.getRoles().stream()
+                            .map(role -> role.replaceAll("^ROLE_", ""))
+                            .collect(Collectors.toList()));
             final CanonicalUser canonicalizedUser = modelMapper.toCanonical(authenticatedUser);
             user = userLinkService//
                     .findUpToDateUser(canonicalizedUser)//

--- a/georchestra-integration/georchestra-authnz/src/test/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilterIT.java
+++ b/georchestra-integration/georchestra-authnz/src/test/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilterIT.java
@@ -19,8 +19,6 @@
 
 package org.georchestra.geonetwork.security.authentication;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.regex.Pattern;
 
@@ -29,7 +27,6 @@ import org.geonetwork.security.external.configuration.ExternalizedSecurityProper
 import org.geonetwork.security.external.integration.AccountsReconcilingService;
 import org.geonetwork.security.external.model.CanonicalUser;
 import org.geonetwork.security.external.model.GroupSyncMode;
-import org.georchestra.config.security.GeorchestraUserDetails;
 import org.georchestra.geonetwork.security.AbstractGeorchestraIntegrationTest;
 import org.georchestra.security.api.UsersApi;
 import org.georchestra.security.model.GeorchestraUser;
@@ -151,6 +148,7 @@ public class GeorchestraPreAuthenticationFilterIT extends AbstractGeorchestraInt
         request.addHeader("sec-orgname", "Project Steering Committee");
         request.addHeader("sec-external-authentication", "false");
         //Should not contains ROLE_ prefix
-        assertThrows("Role EL_PSC not found in internal or external repository", IllegalArgumentException.class, () -> authFilter.getPreAuthenticatedPrincipal(request));
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> authFilter.getPreAuthenticatedPrincipal(request));
+        assertEquals("Role EL_PSC not found in internal or external repository", exception.getMessage());
     }
 }

--- a/georchestra-integration/georchestra-authnz/src/test/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilterIT.java
+++ b/georchestra-integration/georchestra-authnz/src/test/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilterIT.java
@@ -19,15 +19,17 @@
 
 package org.georchestra.geonetwork.security.authentication;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
+import java.util.HashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.regex.Pattern;
 
 import org.fao.geonet.domain.User;
+import org.geonetwork.security.external.configuration.ExternalizedSecurityProperties;
 import org.geonetwork.security.external.integration.AccountsReconcilingService;
 import org.geonetwork.security.external.model.CanonicalUser;
+import org.geonetwork.security.external.model.GroupSyncMode;
+import org.georchestra.config.security.GeorchestraUserDetails;
 import org.georchestra.geonetwork.security.AbstractGeorchestraIntegrationTest;
 import org.georchestra.security.api.UsersApi;
 import org.georchestra.security.model.GeorchestraUser;
@@ -36,12 +38,15 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import static org.junit.Assert.*;
+
 public class GeorchestraPreAuthenticationFilterIT extends AbstractGeorchestraIntegrationTest {
 
     private @Autowired UsersApi consoleUsersApiClient;
     private @Autowired AccountsReconcilingService synchronizationService;
 
     private @Autowired GeorchestraPreAuthenticationFilter authFilter;
+    private @Autowired ExternalizedSecurityProperties configProps;
 
     private MockHttpServletRequest request;
     private GeorchestraUser preAuthTestadmin;
@@ -133,5 +138,19 @@ public class GeorchestraPreAuthenticationFilterIT extends AbstractGeorchestraInt
 
         CanonicalUser canonical = mapper.toCanonical(testreviewer);
         support.assertUser(canonical, found);
+    }
+
+    public @Test void user_with_roles_sync_should_sync_with_groups() {
+        configProps.setSyncMode(GroupSyncMode.roles);
+        configProps.setSyncRolesFilter(Pattern.compile("EL_(.*)"));
+        synchronizationService.synchronize();
+        final String testUserJwt = "{base64}eyJ1c2VybmFtZSI6InRlc3R1c2VyIiwicm9sZXMiOlsiUk9MRV9VU0VSIiwiUk9MRV9JTVBPUlQiLCJST0xFX0dOX0FETUlOIiwiUk9MRV9FTF9QU0MiLCJST0xFX0VMX0NPTVBBTlkiXSwib3JnYW5pemF0aW9uIjoiUFNDIiwiaWQiOiIwNDhiMmYzOC02ZWU3LTRlZWMtOWJlZC0zNDljYzZlYjEzYzMiLCJsYXN0VXBkYXRlZCI6ImY4ODJjNjJhZWY3M2VkZGNmMDgzYzUxNWYyNDlkMGZkYjMyM2U1NTA2Yzg4MTgwNzFiZDAyOWFjNGNiOWY4MTgiLCJmaXJzdE5hbWUiOiJUZXN0IiwibGFzdE5hbWUiOiJVU0VSIiwiZW1haWwiOiJwc2MrdGVzdHVzZXJAZ2VvcmNoZXN0cmEub3JnIiwibm90ZXMiOiJJbnRlcm5hbCBDUk0gbm90ZXMgb24gdGVzdHVzZXIiLCJsZGFwV2FybiI6ZmFsc2UsImlzRXh0ZXJuYWxBdXRoIjpmYWxzZX0=";
+        request = new MockHttpServletRequest();
+        request.addHeader("sec-proxy", "true");
+        request.addHeader("sec-user", testUserJwt);
+        request.addHeader("sec-orgname", "Project Steering Committee");
+        request.addHeader("sec-external-authentication", "false");
+        //Should not contains ROLE_ prefix
+        assertThrows("Role EL_PSC not found in internal or external repository", IllegalArgumentException.class, () -> authFilter.getPreAuthenticatedPrincipal(request));
     }
 }


### PR DESCRIPTION
When connecting with preauth, gn user was sync and checksum updated but groups starting with prefix `ROLE_` didn't exists so it wasn't set in groups. Further sync couldn't work as user had his checksum updated.

It's still prone to errors as it can fail if the group doesn't exist in GN. Also, it doesn't handle GN session, and if GN_ADMIN is removed to a user, he can still see the admin if he doesn't logout/login.

Another solution is to remove `userLinkService.forceMatchingGeonetworkUser` and return null instead to let only sync doing his job.

**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

What does this PR do?
- [ ] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [X] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [x] I have properly filled the [migration-dev-guide.md](/georchestra/geonetwork/blob/georchestra-gn4.4.x/georchestra-migration/migration-dev-guide.md) file, or it is already filled.

