### PR TITLE
feat: extend jetty request header size to work around user holding many roles

### DIFF
--- a/docker/kibana/kibana.yml
+++ b/docker/kibana/kibana.yml
@@ -1,5 +1,5 @@
 server.basePath: "/geonetwork/dashboards"
 server.rewriteBasePath: false
-kibana.index: ".dashboards"
+#kibana.index: ".dashboards"
 # https://github.com/elastic/kibana/issues/12918
 server.host: "0.0.0.0"

--- a/web/src/docker/Dockerfile
+++ b/web/src/docker/Dockerfile
@@ -26,6 +26,7 @@ CMD ["sh", "-c", "exec java \
 -Djava.io.tmpdir=/tmp/jetty \
 -Djava.util.prefs.userRoot=/tmp/userPrefs \
 -Djava.util.prefs.systemRoot=/tmp/systemPrefs \
+-Djetty.httpConfig.requestHeaderSize=65536 \
 -Dgeorchestra.datadir=/etc/georchestra \
 -Dgeonetwork.jeeves.configuration.overrides.file=/etc/georchestra/geonetwork/config/config-overrides-georchestra.xml \
 -Dgeonetwork.dir=/mnt/geonetwork_datadir \


### PR DESCRIPTION
When a user holds a very high number of roles, he might encounter a "HTTP 431" error on his requests to GeoNetwork. 

This PR also removes kibana dashboards as it is not required since kibana/es v8

**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

What does this PR do?
- [ ] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [x] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [x] I have properly filled the [migration-dev-guide.md](/georchestra/geonetwork/blob/georchestra-gn4.4.x/georchestra-migration/migration-dev-guide.md) file, or it is already filled.

