### PR TITLE
Re-enable metrics page for jetty server

### DIFF
--- a/web/src/docker/Dockerfile
+++ b/web/src/docker/Dockerfile
@@ -30,6 +30,7 @@ CMD ["sh", "-c", "exec java \
 -Dgeorchestra.datadir=/etc/georchestra \
 -Dgeonetwork.jeeves.configuration.overrides.file=/etc/georchestra/geonetwork/config/config-overrides-georchestra.xml \
 -Dgeonetwork.dir=/mnt/geonetwork_datadir \
+--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
 -XX:MaxRAMPercentage=80 -XX:+UseParallelGC \
 -XX:-UsePerfData \
 ${JAVA_OPTIONS} \


### PR DESCRIPTION
PR from https://github.com/geonetwork/core-geonetwork/pull/7385

Allow to see monitor/metrics page.

**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

What does this PR do?
- [ ] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [x] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [x] I have properly filled the [migration-dev-guide.md](/georchestra/geonetwork/blob/georchestra-gn4.4.x/georchestra-migration/migration-dev-guide.md) file, or it is already filled.

