### PR TITLE
geonetwork: remove sync by headers

### DIFF
--- a/georchestra-integration/georchestra-authnz/src/main/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilter.java
+++ b/georchestra-integration/georchestra-authnz/src/main/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilter.java
@@ -23,13 +23,9 @@ import static org.georchestra.commons.security.SecurityHeaders.SEC_PROXY;
 
 import javax.servlet.http.HttpServletRequest;
 
-import jeeves.server.UserSession;
-import jeeves.server.sources.http.JeevesServlet;
 import org.fao.geonet.domain.User;
 import org.geonetwork.security.external.configuration.ExternalizedSecurityProperties;
 import org.geonetwork.security.external.integration.AccountsReconcilingService;
-import org.geonetwork.security.external.model.CanonicalUser;
-import org.geonetwork.security.external.model.GroupSyncMode;
 import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.config.security.GeorchestraSecurityProxyAuthenticationFilter;
 import org.georchestra.config.security.GeorchestraUserDetails;

--- a/georchestra-integration/georchestra-authnz/src/main/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilter.java
+++ b/georchestra-integration/georchestra-authnz/src/main/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilter.java
@@ -23,6 +23,8 @@ import static org.georchestra.commons.security.SecurityHeaders.SEC_PROXY;
 
 import javax.servlet.http.HttpServletRequest;
 
+import jeeves.server.UserSession;
+import jeeves.server.sources.http.JeevesServlet;
 import org.fao.geonet.domain.User;
 import org.geonetwork.security.external.configuration.ExternalizedSecurityProperties;
 import org.geonetwork.security.external.integration.AccountsReconcilingService;
@@ -84,30 +86,12 @@ public class GeorchestraPreAuthenticationFilter extends AbstractPreAuthenticated
             log.debug("geOrchestra pre-auth is anonymous. URI: {}", request.getRequestURI());
             return null;
         }
-
-        final GeorchestraUser authenticatedUser = auth.getUser();
-        final boolean isFullyAuthorized = null != authenticatedUser.getLastUpdated();
-        User user;
-        if (configProps.getSyncMode() == GroupSyncMode.roles) {
-            authenticatedUser.setRoles(
-                authenticatedUser.getRoles().stream()
-                    .map(role -> role.replaceAll("^ROLE_", ""))
-                    .collect(Collectors.toList()));
-        }
-        if (isFullyAuthorized) {// sec-user provided full user representation as JSON payload
-            checkMandatoryProperties(auth.getUser());
-            final CanonicalUser canonicalizedUser = modelMapper.toCanonical(authenticatedUser);
-            user = userLinkService//
-                    .findUpToDateUser(canonicalizedUser)//
-                    .orElseGet(() -> userLinkService.forceMatchingGeonetworkUser(canonicalizedUser));
-        } else {// legacy authentication mode, find by username
-            final String userName = authenticatedUser.getUsername();
-            user = userLinkService//
-                    .findUpToDateUserByUsername(userName)//
-                    .orElseGet(() -> userLinkService.forceMatchingGeonetworkUser(userName));
-        }
-
-        return user;
+        return userLinkService//
+                .findUpToDateUserByUsername(auth.getUser().getUsername())//
+                .orElseGet(() -> {
+                    userLinkService.synchronize();
+                    return null;
+                });
     }
 
     private GeorchestraUser checkMandatoryProperties(GeorchestraUser user) {

--- a/georchestra-integration/georchestra-authnz/src/test/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilterIT.java
+++ b/georchestra-integration/georchestra-authnz/src/test/java/org/georchestra/geonetwork/security/authentication/GeorchestraPreAuthenticationFilterIT.java
@@ -103,7 +103,7 @@ public class GeorchestraPreAuthenticationFilterIT extends AbstractGeorchestraInt
 
         User createdUponAuthentication = authFilter.getPreAuthenticatedPrincipal(request);
 
-        assertNotNull(createdUponAuthentication);
+        assertNull(createdUponAuthentication);
 
         User found = synchronizationService.findUpToDateUserByUsername(consoleUser.getUsername())
                 .orElseThrow(() -> new IllegalStateException("user should have been synchronized"));
@@ -135,20 +135,5 @@ public class GeorchestraPreAuthenticationFilterIT extends AbstractGeorchestraInt
 
         CanonicalUser canonical = mapper.toCanonical(testreviewer);
         support.assertUser(canonical, found);
-    }
-
-    public @Test void user_with_roles_sync_should_sync_with_groups() {
-        configProps.setSyncMode(GroupSyncMode.roles);
-        configProps.setSyncRolesFilter(Pattern.compile("EL_(.*)"));
-        synchronizationService.synchronize();
-        final String testUserJwt = "{base64}eyJ1c2VybmFtZSI6InRlc3R1c2VyIiwicm9sZXMiOlsiUk9MRV9VU0VSIiwiUk9MRV9JTVBPUlQiLCJST0xFX0dOX0FETUlOIiwiUk9MRV9FTF9QU0MiLCJST0xFX0VMX0NPTVBBTlkiXSwib3JnYW5pemF0aW9uIjoiUFNDIiwiaWQiOiIwNDhiMmYzOC02ZWU3LTRlZWMtOWJlZC0zNDljYzZlYjEzYzMiLCJsYXN0VXBkYXRlZCI6ImY4ODJjNjJhZWY3M2VkZGNmMDgzYzUxNWYyNDlkMGZkYjMyM2U1NTA2Yzg4MTgwNzFiZDAyOWFjNGNiOWY4MTgiLCJmaXJzdE5hbWUiOiJUZXN0IiwibGFzdE5hbWUiOiJVU0VSIiwiZW1haWwiOiJwc2MrdGVzdHVzZXJAZ2VvcmNoZXN0cmEub3JnIiwibm90ZXMiOiJJbnRlcm5hbCBDUk0gbm90ZXMgb24gdGVzdHVzZXIiLCJsZGFwV2FybiI6ZmFsc2UsImlzRXh0ZXJuYWxBdXRoIjpmYWxzZX0=";
-        request = new MockHttpServletRequest();
-        request.addHeader("sec-proxy", "true");
-        request.addHeader("sec-user", testUserJwt);
-        request.addHeader("sec-orgname", "Project Steering Committee");
-        request.addHeader("sec-external-authentication", "false");
-        //Should not contains ROLE_ prefix
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> authFilter.getPreAuthenticatedPrincipal(request));
-        assertEquals("Role EL_PSC not found in internal or external repository", exception.getMessage());
     }
 }


### PR DESCRIPTION
This PR remove the update of specific user based on headers. It resync correctly users based on what is done on normal synchronization.

It avoids to have a user which seems synchronized but his groups aren't. 

**geOrchestra/geonetwork checklist**
<!--- In order to ease future geonetwork migrations: -->

What does this PR do?
- [ ] PR only involves cherry-picked commits from upstream.
- [ ] PR contains custom code which will soon be available in an upstream release and can be overriden => mention core-geonetwork version if possible.
- [x] PR contains custom geOrchestra code, which need to be verified during future migrations.
  -  [x] I have properly filled the [migration-dev-guide.md](/georchestra/geonetwork/blob/georchestra-gn4.4.x/georchestra-migration/migration-dev-guide.md) file, or it is already filled.

