### PR TITLE
Fix: attempt to fix CSW filters with empty escapeChar

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
@@ -158,7 +158,9 @@ public class CswFilter2Es extends AbstractFilterVisitor {
         // For example, if the wildcard is % and the escape character is \:
         //  - in the previous replacement %afr\%ca% becomes *afr\*ca*
         //  - and with this replacement *afr\*ca* becomes *afr\%ca*
-        result = result.replaceAll(Pattern.quote(escapeWildcardDefault), wildcardChar);
+        // Skip if the escapeChar is an empty string, to avoid reverting previous change
+        if (! StringUtils.isEmpty(filter.getEscape()))
+            result = result.replaceAll(Pattern.quote(escapeWildcardDefault), wildcardChar);
 
         if (wildcardChar.equals("%")) {
             // Escape % for String.format used in SearchController to process the csw filter
@@ -171,7 +173,9 @@ public class CswFilter2Es extends AbstractFilterVisitor {
             String escapeSinglecharDefault = filter.getEscape() + "?";
 
             result = result.replaceAll(Pattern.quote(singleChar), "?");
-            result = result.replaceAll(Pattern.quote(escapeSinglecharDefault), singleChar);
+            // Skip if the escapeChar is an empty string, to avoid reverting previous change
+            if (! StringUtils.isEmpty(filter.getEscape()))
+                result = result.replaceAll(Pattern.quote(escapeSinglecharDefault), singleChar);
 
             if (singleChar.equals("%")) {
                 result = result.replace( singleChar, "%%");

--- a/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2EsTest.java
+++ b/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2EsTest.java
@@ -196,6 +196,26 @@ class CswFilter2EsTest {
     }
 
     @Test
+    void testUuidPropertyIsLike() throws IOException {
+
+        final String input =
+            "      <Filter xmlns=\"http://www.opengis.net/ogc\">\n" +
+            "         <PropertyIsLike wildCard=\"%\" singleChar=\"_\" escapeChar=\"\">\n" +
+            "            <PropertyName>dc:identifier</PropertyName>\n" +
+            "            <Literal>%</Literal>\n" +
+            "        </PropertyIsLike>\n" +
+            "      </Filter>\n";
+
+        // EXPECTED:
+        final ObjectNode expected = EsJsonHelper.boolbdr(). //
+            must(array(queryStringPart("dc:identifier", "*"))). //
+            filter(queryStringPart()). //
+            bld();
+
+        assertFilterEquals(expected, input);
+    }
+
+    @Test
     void testPropertyIsLikeSpecialChars() throws IOException {
 
         final String input =


### PR DESCRIPTION
See https://github.com/geonetwork/core-geonetwork/issues/9095 for the motivation.

Added a utest to make sure the generated ES filter is coherent.

Waiting for feedback on the issue before opening the same PR upstream.