### PR TITLE
fix: remove userinfo field from the ES index

### DIFF
--- a/.github/workflows/build-java11.yml
+++ b/.github/workflows/build-java11.yml
@@ -16,6 +16,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: true
+        # all of these default to true, but feel free to set to
+        # "false" if necessary for your workflow
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: false
+
     - name: "Checking out"
       uses: actions/checkout@v2.4.0
       with:

--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -646,7 +646,6 @@ public final class Geonet {
         public static final String RATING = "_rating";
         public static final String DISPLAY_ORDER = "_displayOrder";
         public static final String EXTRA = "_extra";
-        public static final String USERINFO = "_userinfo";
         public static final String GROUP_OWNER = "groupOwner";
         public static final String GROUP_WEBSITE = "_groupWebsite";
         public static final String LOGO = "_logo";

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -422,8 +422,6 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
                     Optional<User> userOpt = userRepository.findById(fullMd.getSourceInfo().getOwner());
                     if (userOpt.isPresent()) {
                         User user = userOpt.get();
-                        fields.put(Geonet.IndexFieldNames.USERINFO, user.getUsername() + "|" + user.getSurname() + "|" + user
-                            .getName() + "|" + user.getProfile());
                         fields.put(Geonet.IndexFieldNames.OWNERNAME, user.getName() + " " + user.getSurname());
                     }
                 }


### PR DESCRIPTION
It is considered a sensitive info to reveal user identifiers and their profiles, as the field does not seem to be used client side, maybe it is safer just not to index as it is.

Tests: untested yet.