### PR TITLE
New Group Sync for GN

### DIFF
--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/AbstractGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/AbstractGroupSynchronizer.java
@@ -237,4 +237,8 @@ abstract class AbstractGroupSynchronizer implements GroupSynchronizer {
         return profileMappings.resolveHighestProfileFromRoleNames(roles);
     }
 
+    public List<String> getRootRolesForUser(@NonNull CanonicalUser user) {
+        return user.getRoles();
+    }
+
 }

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/AbstractGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/AbstractGroupSynchronizer.java
@@ -237,6 +237,7 @@ abstract class AbstractGroupSynchronizer implements GroupSynchronizer {
         return profileMappings.resolveHighestProfileFromRoleNames(roles);
     }
 
+    @Override
     public List<String> getRootRolesForUser(@NonNull CanonicalUser user) {
         return user.getRoles();
     }

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/GroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/GroupSynchronizer.java
@@ -72,8 +72,10 @@ interface GroupSynchronizer {
     Privileges resolvePrivilegesFor(CanonicalUser user);
 
     /**
-     * Returns the names of the root roles (non group-specific) assigned to the given user in the
-     * external system.
+     * Returns the names of roles assigned to the given user in the external
+     * system, normalized by stripping any org/group prefix from the role name.
+     * Returned values therefore represent normalized role names and should not
+     * be interpreted as guaranteed global-only roles in the external system.
      */
     List<String> getRootRolesForUser(@NonNull CanonicalUser user);
 }

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/GroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/GroupSynchronizer.java
@@ -70,4 +70,10 @@ interface GroupSynchronizer {
      * {@link Group} and and external {@link GroupLink link} in the process.
      */
     Privileges resolvePrivilegesFor(CanonicalUser user);
+
+    /**
+     * Returns the names of the root roles (non group-specific) assigned to the given user in the
+     * external system.
+     */
+    List<String> getRootRolesForUser(@NonNull CanonicalUser user);
 }

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/GroupSynchronizerProxy.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/GroupSynchronizerProxy.java
@@ -82,4 +82,8 @@ class GroupSynchronizerProxy implements GroupSynchronizer {
     public @Override Privileges resolvePrivilegesFor(CanonicalUser user) {
         return resolve().resolvePrivilegesFor(user);
     }
+
+    public @Override List<String> getRootRolesForUser(CanonicalUser user) {
+        return resolve().getRootRolesForUser(user);
+    }
 }

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/GroupSynchronizerProxy.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/GroupSynchronizerProxy.java
@@ -39,6 +39,7 @@ class GroupSynchronizerProxy implements GroupSynchronizer {
 
     private @Autowired OrgsBasedGroupSynchronizer orgsSynchronizer;
     private @Autowired RolesBasedGroupSynchronizer rolesSynchronizer;
+    private @Autowired RolePerOrgBasedGroupSynchronizer rolePerOrgSynchronizer;
 
     private GroupSynchronizer resolve() {
         final GroupSyncMode syncMode = props.getSyncMode();
@@ -47,6 +48,8 @@ class GroupSynchronizerProxy implements GroupSynchronizer {
             return orgsSynchronizer;
         case roles:
             return rolesSynchronizer;
+        case role_per_org:
+            return rolePerOrgSynchronizer;
         default:
             throw new IllegalStateException("Invalid sync mode: " + syncMode);
         }

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/IntegrationConfiguration.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/IntegrationConfiguration.java
@@ -51,6 +51,10 @@ public class IntegrationConfiguration {
         return new OrgsBasedGroupSynchronizer(canonicalAccountsRepository);
     }
 
+    protected @Bean RolePerOrgBasedGroupSynchronizer rolePerOrgBasedGroupSynchronizer() {
+        return new RolePerOrgBasedGroupSynchronizer(canonicalAccountsRepository);
+    }
+
     protected @Bean LogoUpdater logoUpdater() {
         return new LogoUpdater(canonicalAccountsRepository);
     }

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
@@ -62,14 +62,17 @@ public class RolePerOrgBasedGroupSynchronizer extends AbstractGroupSynchronizer 
 
     protected @Override List<CanonicalGroup> resolveGroupsOf(CanonicalUser user) {
         final String orgName = user.getOrganization();
-        if (!StringUtils.hasLength(orgName)) {
-            return Collections.emptyList();
-        }
         Stream<String> groupsName = userRoles(user)
-            .map(r -> r.contains(separator) ? r.split(separator)[0] : orgName
-            ).distinct();
+            .flatMap(r -> {
+                if (r.contains(separator)) {
+                    return Stream.of(r.split(separator)[0]);
+                }
+                return StringUtils.hasLength(orgName) ? Stream.of(orgName) : Stream.empty();
+            })
+            .distinct();
         Stream<CanonicalGroup> roleGroups = groupsName.map(role -> this.externalGroupLinks.findByName(role)//
             .map(GroupLink::getCanonical)
+            .or(() -> canonicalAccounts.findOrganizationByName(role))
             .orElseThrow(notFound(role)));
         return roleGroups.collect(Collectors.toList());
     }

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
@@ -98,7 +98,13 @@ public class RolePerOrgBasedGroupSynchronizer extends AbstractGroupSynchronizer 
     private Privilege resolvePrivilegeFor(CanonicalUser user, Group group) {
         String groupPrefix = group.getName() + separator;
         List<String> rolesForGroup = userRoles(user)
-            .filter(r -> r.startsWith(groupPrefix) || config.getProfiles().getRolemappings().keySet().contains(r)) //e.g filter roles for this group PSC:GN_REVIEWER and GN_EDITOR
+            .filter(r -> {
+                if (r.contains(separator)) {
+                    return r.startsWith(groupPrefix);
+                } else {
+                    return group.getName().equals(user.getOrganization());
+                }
+            }) //e.g filter roles for this group PSC:GN_REVIEWER and GN_EDITOR //e.g filter roles for this group PSC:GN_REVIEWER and GN_EDITOR
             .map(this::getRootRole) // e.g get only the role part GN_REVIEWER
             .collect(Collectors.toList());
         Profile p = config.getProfiles().resolveHighestProfileFromRoleNames(rolesForGroup); // resolve highest profile for the roles filtered, here GN_REVIEWER

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
@@ -94,8 +94,9 @@ public class RolePerOrgBasedGroupSynchronizer extends AbstractGroupSynchronizer 
     }
 
     private Stream<String> userRoles(CanonicalUser user) {
+        Pattern p = Pattern.compile(".+" + separator + ".+");
         return user.getRoles().stream()
-            .filter(r -> Pattern.compile(".+" + separator + ".+").matcher(r).matches() || config.getProfiles().getRolemappings().keySet().contains(r));
+            .filter(r -> p.matcher(r).matches() || config.getProfiles().getRolemappings().containsKey(r));
     }
 
     private Privilege resolvePrivilegeFor(CanonicalUser user, Group group) {

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
@@ -104,7 +104,7 @@ public class RolePerOrgBasedGroupSynchronizer extends AbstractGroupSynchronizer 
                 } else {
                     return group.getName().equals(user.getOrganization());
                 }
-            }) //e.g filter roles for this group PSC:GN_REVIEWER and GN_EDITOR //e.g filter roles for this group PSC:GN_REVIEWER and GN_EDITOR
+            }) //e.g filter roles for this group PSC:GN_REVIEWER and GN_EDITOR
             .map(this::getRootRole) // e.g get only the role part GN_REVIEWER
             .collect(Collectors.toList());
         Profile p = config.getProfiles().resolveHighestProfileFromRoleNames(rolesForGroup); // resolve highest profile for the roles filtered, here GN_REVIEWER
@@ -118,7 +118,8 @@ public class RolePerOrgBasedGroupSynchronizer extends AbstractGroupSynchronizer 
 
     @Override
     public List<String> getRootRolesForUser(CanonicalUser user) {
-        // Not used in RolePerOrg mode
+        // Used to resolve the user's global/default profile: returns relevant role names
+        // with any organization prefix stripped (for example, PSC:GN_REVIEWER -> GN_REVIEWER).
         return userRoles(user).map(this::getRootRole).collect(Collectors.toList());
     }
 

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2009-2025 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.geonetwork.security.external.integration;
+
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.Profile;
+import org.geonetwork.security.external.configuration.ExternalizedSecurityProperties;
+import org.geonetwork.security.external.model.CanonicalGroup;
+import org.geonetwork.security.external.model.CanonicalUser;
+import org.geonetwork.security.external.model.GroupLink;
+import org.geonetwork.security.external.model.GroupSyncMode;
+import org.geonetwork.security.external.repository.CanonicalAccountsRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class RolePerOrgBasedGroupSynchronizer extends AbstractGroupSynchronizer {
+
+    public static final Logger log = LoggerFactory.getLogger(RolePerOrgBasedGroupSynchronizer.class.getPackage().getName());
+
+    private static final String separator = ":";
+
+    @Autowired
+    public ExternalizedSecurityProperties config;
+
+    public RolePerOrgBasedGroupSynchronizer(CanonicalAccountsRepository canonicalAccounts) {
+        super(canonicalAccounts);
+    }
+
+    protected @Override GroupSyncMode getOrigin() {
+        return GroupSyncMode.role_per_org;
+    }
+
+    public @Override List<CanonicalGroup> fetchCanonicalGroups() {
+        return canonicalAccounts.findAllOrganizations();
+    }
+
+    protected @Override List<CanonicalGroup> resolveGroupsOf(CanonicalUser user) {
+        final String orgName = user.getOrganization();
+        if(!StringUtils.hasLength(orgName)) {
+            return Collections.emptyList();
+        }
+        Stream<String> groupsName = userRoles(user)
+            .map(r -> r.contains(separator) ? r.split(separator)[0] : orgName
+            ).distinct();
+        Stream<CanonicalGroup> roleGroups = groupsName.map(role -> this.externalGroupLinks.findByName(role)//
+                .map(GroupLink::getCanonical)
+                .orElseThrow(notFound(role)));
+        return roleGroups.collect(Collectors.toList());
+    }
+
+    @Override
+    public Privileges resolvePrivilegesFor(CanonicalUser user) {
+        final List<CanonicalGroup> canonicalGroups = resolveGroupsOf(user);
+
+        Privileges userPrivileges = new Privileges(resolveDefaultProfile(user));
+        Stream<Group> groups = canonicalGroups.stream().map(this::synchronize).map(GroupLink::getGeonetworkGroup);
+        groups.map(g -> resolvePrivilegeFor(user, g))
+            .forEach(userPrivileges.getAdditionalProvileges()::add);
+        return userPrivileges;
+    }
+
+    @Override
+    protected Profile resolveDefaultProfile(CanonicalUser user) {
+        return configProperties.getProfiles().resolveHighestProfileFromRoleNames(userRoles(user).map(r -> r.contains(separator) ? r.split(separator)[1] : r).collect(Collectors.toList()));
+    }
+
+    private Stream<String> userRoles(CanonicalUser user){
+        return user.getRoles().stream()
+            .filter(r -> Pattern.compile(".+"+ separator + ".+").matcher(r).matches() || config.getProfiles().getRolemappings().keySet().contains(r));
+    }
+
+    private Privilege resolvePrivilegeFor(CanonicalUser user, Group group) {
+        String groupPrefix = group.getName() + separator;
+        List<String> rolesForGroup = user.getRoles().stream()
+            .filter(r -> r.startsWith(groupPrefix) || config.getProfiles().getRolemappings().keySet().contains(r)) //e.g filter roles for this group PSC:GN_REVIEWER and GN_EDITOR
+            .map(r -> r.contains(separator) ? r.split(separator)[1] : r) // e.g get only the role part GN_REVIEWER
+            .collect(Collectors.toList());
+        Profile p = config.getProfiles().resolveHighestProfileFromRoleNames(rolesForGroup); // resolve highest profile for the roles filtered, here GN_REVIEWER
+        return new Privilege(group, p);
+    }
+
+    private Supplier<? extends IllegalArgumentException> notFound(final String orgName) {
+        return () -> new IllegalArgumentException(
+            "Organization with name '" + orgName + "' not found in internal nor external repository");
+    }
+
+}

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
@@ -39,6 +39,11 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Synchronizes geOrchestra groups with external groups based on the user's organization and roles.
+ * For each organization, a corresponding geOrchestra group is created (if it doesn't exist) and the user is added to it if they belong to that organization.
+ * Additionally, if the user's roles contain an organization prefix (e.g., "ORG:ROLE"), the user is added to the group corresponding to that organization (e.g., "ORG").
+ */
 public class RolePerOrgBasedGroupSynchronizer extends AbstractGroupSynchronizer {
 
     public static final Logger log = LoggerFactory.getLogger(RolePerOrgBasedGroupSynchronizer.class.getPackage().getName());

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolePerOrgBasedGroupSynchronizer.java
@@ -62,15 +62,15 @@ public class RolePerOrgBasedGroupSynchronizer extends AbstractGroupSynchronizer 
 
     protected @Override List<CanonicalGroup> resolveGroupsOf(CanonicalUser user) {
         final String orgName = user.getOrganization();
-        if(!StringUtils.hasLength(orgName)) {
+        if (!StringUtils.hasLength(orgName)) {
             return Collections.emptyList();
         }
         Stream<String> groupsName = userRoles(user)
             .map(r -> r.contains(separator) ? r.split(separator)[0] : orgName
             ).distinct();
         Stream<CanonicalGroup> roleGroups = groupsName.map(role -> this.externalGroupLinks.findByName(role)//
-                .map(GroupLink::getCanonical)
-                .orElseThrow(notFound(role)));
+            .map(GroupLink::getCanonical)
+            .orElseThrow(notFound(role)));
         return roleGroups.collect(Collectors.toList());
     }
 
@@ -87,19 +87,19 @@ public class RolePerOrgBasedGroupSynchronizer extends AbstractGroupSynchronizer 
 
     @Override
     protected Profile resolveDefaultProfile(CanonicalUser user) {
-        return configProperties.getProfiles().resolveHighestProfileFromRoleNames(userRoles(user).map(r -> r.contains(separator) ? r.split(separator)[1] : r).collect(Collectors.toList()));
+        return configProperties.getProfiles().resolveHighestProfileFromRoleNames(getRootRolesForUser(user));
     }
 
-    private Stream<String> userRoles(CanonicalUser user){
+    private Stream<String> userRoles(CanonicalUser user) {
         return user.getRoles().stream()
-            .filter(r -> Pattern.compile(".+"+ separator + ".+").matcher(r).matches() || config.getProfiles().getRolemappings().keySet().contains(r));
+            .filter(r -> Pattern.compile(".+" + separator + ".+").matcher(r).matches() || config.getProfiles().getRolemappings().keySet().contains(r));
     }
 
     private Privilege resolvePrivilegeFor(CanonicalUser user, Group group) {
         String groupPrefix = group.getName() + separator;
-        List<String> rolesForGroup = user.getRoles().stream()
+        List<String> rolesForGroup = userRoles(user)
             .filter(r -> r.startsWith(groupPrefix) || config.getProfiles().getRolemappings().keySet().contains(r)) //e.g filter roles for this group PSC:GN_REVIEWER and GN_EDITOR
-            .map(r -> r.contains(separator) ? r.split(separator)[1] : r) // e.g get only the role part GN_REVIEWER
+            .map(this::getRootRole) // e.g get only the role part GN_REVIEWER
             .collect(Collectors.toList());
         Profile p = config.getProfiles().resolveHighestProfileFromRoleNames(rolesForGroup); // resolve highest profile for the roles filtered, here GN_REVIEWER
         return new Privilege(group, p);
@@ -108,6 +108,19 @@ public class RolePerOrgBasedGroupSynchronizer extends AbstractGroupSynchronizer 
     private Supplier<? extends IllegalArgumentException> notFound(final String orgName) {
         return () -> new IllegalArgumentException(
             "Organization with name '" + orgName + "' not found in internal nor external repository");
+    }
+
+    @Override
+    public List<String> getRootRolesForUser(CanonicalUser user) {
+        // Not used in RolePerOrg mode
+        return userRoles(user).map(this::getRootRole).collect(Collectors.toList());
+    }
+
+    private String getRootRole(String role) {
+        if (role.contains(separator)) {
+            return role.split(separator)[1];
+        }
+        return role;
     }
 
 }

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolesBasedGroupSynchronizer.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/integration/RolesBasedGroupSynchronizer.java
@@ -40,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static java.util.Objects.*;
 
+@Deprecated
 public class RolesBasedGroupSynchronizer extends AbstractGroupSynchronizer {
 
     public static final Logger log = LoggerFactory.getLogger(RolesBasedGroupSynchronizer.class.getPackage().getName());

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/model/GroupSyncMode.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/model/GroupSyncMode.java
@@ -25,5 +25,5 @@ import org.fao.geonet.domain.Group;
  * external system's Organizations or Roles.
  */
 public enum GroupSyncMode {
-    orgs, roles;
+    orgs, roles, role_per_org;
 }

--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/model/GroupSyncMode.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/model/GroupSyncMode.java
@@ -25,5 +25,7 @@ import org.fao.geonet.domain.Group;
  * external system's Organizations or Roles.
  */
 public enum GroupSyncMode {
-    orgs, roles, role_per_org;
+    orgs,
+    roles, //deprecated
+    role_per_org;
 }

--- a/georchestra-integration/externalized-accounts/src/test/java/org/geonetwork/security/external/integration/IntegrationTestSupport.java
+++ b/georchestra-integration/externalized-accounts/src/test/java/org/geonetwork/security/external/integration/IntegrationTestSupport.java
@@ -87,6 +87,10 @@ public class IntegrationTestSupport extends ExternalResource {
         configProps.setSyncMode(GroupSyncMode.roles);
     }
 
+    public void setRolePerOrgSyncMode() {
+        configProps.setSyncMode(GroupSyncMode.role_per_org);
+    }
+
     public ProfileMappingProperties getProfileMappings() {
         return configProps.getProfiles();
     }
@@ -136,7 +140,7 @@ public class IntegrationTestSupport extends ExternalResource {
         assertEquals(expectedTitle, user.getKind());
 
         ProfileMappingProperties profileMappings = configProps.getProfiles();
-        Profile expectedProfile = profileMappings.resolveHighestProfileFromRoleNames(expected.getRoles());
+        Profile expectedProfile = profileMappings.resolveHighestProfileFromRoleNames(groupSynchronizer.getRootRolesForUser(expected));
         assertEquals(expectedProfile, user.getProfile());
     }
 

--- a/georchestra-integration/externalized-accounts/src/test/java/org/geonetwork/security/external/integration/RolePerOrgBasedSynchronizationIT.java
+++ b/georchestra-integration/externalized-accounts/src/test/java/org/geonetwork/security/external/integration/RolePerOrgBasedSynchronizationIT.java
@@ -61,7 +61,6 @@ public class RolePerOrgBasedSynchronizationIT extends AbstractAccountsReconcilin
         CanonicalGroup org = orgGroups.get(0); // just to be explicit
         CanonicalGroup role = super.createRole("PSC:GN_REVIEWER"); // role name in external repo
         List<CanonicalGroup> orgs = new ArrayList<>(super.defaultGroups);
-        orgs.add(org);
 
         // Create a user that belongs to organization "PSC" and has role "PSC:GN_REVIEWER"
         CanonicalUser u = super.setUpNewUser("prefixed", org, role);

--- a/georchestra-integration/externalized-accounts/src/test/java/org/geonetwork/security/external/integration/RolePerOrgBasedSynchronizationIT.java
+++ b/georchestra-integration/externalized-accounts/src/test/java/org/geonetwork/security/external/integration/RolePerOrgBasedSynchronizationIT.java
@@ -1,0 +1,92 @@
+// java
+package org.geonetwork.security.external.integration;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import javax.transaction.Transactional;
+
+import org.assertj.core.util.Sets;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.User;
+import org.geonetwork.security.external.configuration.ExternalizedSecurityProperties;
+import org.geonetwork.security.external.model.CanonicalGroup;
+import org.geonetwork.security.external.model.CanonicalUser;
+import org.geonetwork.security.external.model.GroupLink;
+import org.geonetwork.security.external.model.UserLink;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.annotation.DirtiesContext;
+
+@Transactional
+@DirtiesContext
+public class RolePerOrgBasedSynchronizationIT extends AbstractAccountsReconcilingServiceIntegrationTest {
+
+    @Before
+    public void setUp_SetSyncModeToRolePerOrg() {
+        support.setRolePerOrgSyncMode();
+    }
+
+
+    @Test
+    public void Synchronize_on_empty_geonetwork_db_creates_all_users_and_groups_from_orgs() {
+        List<CanonicalUser> users = super.defaultUsers;
+        List<CanonicalGroup> orgs = super.defaultGroups;
+
+        assertEquals(0, support.gnUserRepository.count());
+        assertEquals(0, support.gnGroupRepository.count());
+
+        service.synchronize();
+        verify(users, orgs);
+    }
+
+    @Test
+    public void RolePerOrg_user_with_prefixed_role_maps_to_org_group() {
+        List<CanonicalGroup> orgGroups = super.defaultGroups;
+        CanonicalGroup org = orgGroups.get(0); // just to be explicit
+        CanonicalGroup role = super.createRole("PSC:GN_REVIEWER"); // role name in external repo
+        List<CanonicalGroup> orgs = new ArrayList<>(super.defaultGroups);
+        orgs.add(org);
+
+        // Create a user that belongs to organization "PSC" and has role "PSC:GN_REVIEWER"
+        CanonicalUser u = super.setUpNewUser("prefixed", org, role);
+
+        when(canonicalAccountsRepositoryMock.findAllOrganizations()).thenReturn(orgs);
+        when(canonicalAccountsRepositoryMock.findAllUsers()).thenReturn(List.of(u));
+
+        service.synchronize();
+
+        // verify group link exists for the organization and user is linked to it
+        //support.assertGroupLinkassertUserLink(org);
+        UserLink link = support.assertUserLink(u);
+        support.assertGroup(link.getInternalUser(), org);
+    }
+
+
+    private void verify(List<CanonicalUser> expectedUsers, List<CanonicalGroup> expectedOrgs) {
+        assertEquals(expectedOrgs.size(), support.groupLinkRepository.findAll().size());
+        assertEquals(expectedUsers.size(), support.userLinkRepository.findAll().size());
+
+        for (CanonicalGroup expected : expectedOrgs) {
+            support.assertGroupLink(expected);
+        }
+        for (CanonicalUser expected : expectedUsers) {
+            support.assertUserLink(expected);
+        }
+    }
+}

--- a/georchestra-integration/pom.xml
+++ b/georchestra-integration/pom.xml
@@ -12,7 +12,7 @@
   <name>geOrchestra integration</name>
   <properties>
     <rootProjectDir>${basedir}/..</rootProjectDir>
-    <georchestra.version>25.0.0</georchestra.version>
+    <georchestra.version>25.0.3</georchestra.version>
   </properties>
   <modules>
     <module>georchestra-utils</module>


### PR DESCRIPTION
I introduce here a new synchronization for geonetwork in georchestra in order to solve the current situation of:

- Org based sync is not granular enough to be able to give a user rights in different groups
- Role based sync is not understable enough and we easily lose track of what is synced between georchestra's console and GN

## How does it work

This new sync works (almost) like Org based sync. Organization in georchestra are mapped to GN groups. 

But, we can also create new roles in georchestra like PSC:GN_REVIEWER which will allow user to be REVIEWER of PSC group.

In this way, we can set multiple and differents rights for user  like PSC:GN_REVIEWER, C2C:GN_EDITOR and so on.

Top level roles like GN_EDITOR, GN_REVIEWER set this role for organization/group where user belongs to (just as org based sync).

Requires: https://github.com/georchestra/georchestra/pull/4616
and https://github.com/georchestra/georchestra/pull/4656


## Examples

|User|Profile in GN|Roles in GN|
|---|---|---|
| Organization PSC, Roles: ROLE_USER|Guest|No group attribution|
| No Organization , Roles: GN_EDITOR|Editor|No group attribution|
| Organization PSC , Roles: GN_EDITOR|Editor|Editor in PSC Group|
| Organization PSC , Roles: GN_EDITOR, C3P:GN_REVIEWER|Reviewer|Editor in PSC Group, Reviewer in C3P Group|
| No Org, Roles: GN_ADMIN|Administrator|Admin in all groups|

GIP: https://github.com/georchestra/improvement-proposals/issues/16
