### PR TITLE
fix: thesaurus retrieval from UI when editing a metadata

### DIFF
--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
@@ -146,7 +146,7 @@
             thesaurus: thesaurus,
             rows: max,
             q: filter || "",
-            uri: "*" + filter + "*" || "",
+            uri: (typeSearch === "MATCH" ? filter : "*" + filter + "*") || "",
             lang: lang || "eng"
           };
           if (outputLang) {


### PR DESCRIPTION
When a thesaurus contains keys which can be contained in another, it may display the wrong key when editing a metadata.

By example, there's two thesaurus keys `http://domain.com/mykey/1` and `http://domain.com/mykey/12`.

Depending on the order in the thesaurus, if I have the first one in my metadata record, geonetwork may answer with the second one.

How to replicate: 
- Import this thesaurus [place-test.zip](https://github.com/user-attachments/files/25042528/place-test.zip)
- Edit/create a record and add this thesaurus with `Test 1` keyword
- Save and close
- Check value: Will be ok `Test 1` 
- Re-edit the record and go to thesaurus part
- 🚫 The value show will be `Test wrong`