### PR TITLE
fix: delete user saved selections if user is gone

### DIFF
--- a/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/repository/UserLinkRepository.java
+++ b/georchestra-integration/externalized-accounts/src/main/java/org/geonetwork/security/external/repository/UserLinkRepository.java
@@ -34,6 +34,7 @@ import org.fao.geonet.domain.external.ExternalUserLink;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.UserGroupRepository;
 import org.fao.geonet.repository.UserRepository;
+import org.fao.geonet.repository.UserSavedSelectionRepository;
 import org.fao.geonet.repository.specification.MetadataSpecs;
 import org.geonetwork.security.external.model.UserLink;
 import org.geonetwork.security.external.repository.jpa.ExternalUserLinkRepository;
@@ -53,6 +54,7 @@ public class UserLinkRepository {
     private @Autowired UserRepository gnUserRepository;
     private @Autowired UserGroupRepository userGroupRepository;
     private @Autowired IMetadataUtils metadataRepository;
+    private @Autowired UserSavedSelectionRepository userSavedSelectionRepository;
 
     private @Autowired ExternalUserLinkRepository linksRepo;
 
@@ -105,6 +107,7 @@ public class UserLinkRepository {
         delete(link);
         int userId = link.getInternalUser().getId();
         this.userGroupRepository.deleteAllByIdAttribute(UserGroupId_.userId, Collections.singleton(userId));
+        this.userSavedSelectionRepository.deleteAllByUser(userId);
         this.gnUserRepository.delete(link.getInternalUser());
     }
 


### PR DESCRIPTION
Sometimes, user synchronization was failing with the error: 
```
Caused by: org.postgresql.util.PSQLException: ERROR: update or delete on table "users" violates foreign key constraint "fkq971r8i90nbrn42wgw43f71bd" on table "usersavedselections"                                       │
│   Detail: Key (id)=(401) is still referenced from table "usersavedselections".
```

It's because someone who doesn't exist anymore has used the "Favorite" functionnality of GN (often used with datahub)

So we now delete those selections before trying to delete user.