### PR TITLE
feat: add docker OCI labels

### DIFF
--- a/web/src/docker/Dockerfile
+++ b/web/src/docker/Dockerfile
@@ -20,6 +20,15 @@ USER jetty
 
 VOLUME [ "/mnt/geonetwork_datadir", "/tmp", "/run/jetty" ]
 
+# OCI image labels (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
+LABEL org.opencontainers.image.title="GeoNetwork (geOrchestra)" \
+      org.opencontainers.image.description="GeoNetwork metadata catalog, geOrchestra distribution" \
+      org.opencontainers.image.source="https://github.com/georchestra/geonetwork" \
+      org.opencontainers.image.url="https://github.com/georchestra/geonetwork" \
+      org.opencontainers.image.documentation="https://docs.georchestra.org/" \
+      org.opencontainers.image.vendor="geOrchestra" \
+      org.opencontainers.image.licenses="GPL-2.0-only"
+
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 
 CMD ["sh", "-c", "exec java \


### PR DESCRIPTION
useful for renovate to recognize changelog and source of dockerfile: https://docs.renovatebot.com/key-concepts/changelogs/

also clearly state info such as license, description.

useful also for vulnerability scanners to identify which team owns an image or which license is being used, helping to maintain a better security posture.