### PR TITLE
Remove kibana's healthcheck in config-service-monitoring.xml

### DIFF
--- a/web/src/main/webapp/WEB-INF/config/config-service-monitoring.xml
+++ b/web/src/main/webapp/WEB-INF/config/config-service-monitoring.xml
@@ -34,7 +34,6 @@
     <criticalHealthCheck class=".IndexHealthCheck"/>
     <warningHealthCheck class=".DeadlockedThreadsHealthCheck"/>
     <warningHealthCheck class=".HarvestersHealthCheck"/>
-    <warningHealthCheck class=".DashboardAppHealthCheck"/>
     <warningHealthCheck class=".NoIndexErrorsHealthCheck"/>
     <warningHealthCheck class=".IndexReadOnlyHealthCheck"/>
     <warningHealthCheck class=".FreeConnectionsHealthCheck"/>


### PR DESCRIPTION
This PR removes Kibana's healthcheck in admin UI on because if one check fails it ends up with an error and displays a 500 with security proxy or gateway. 

As Kibana's is often, not configured, I propose to remove this healthcheck here by default. 