### PR TITLE
Add recordDate entry to elasticsearch index

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -319,6 +319,21 @@
                                   $fieldName, ., $allLanguages)"/>
       </xsl:for-each-group>
 
+      <xsl:for-each select="mdb:dateInfo">
+        <xsl:variable name="dateType"
+                          select="cit:CI_Date/cit:dateType/cit:CI_DateTypeCode/@codeListValue"
+                          as="xs:string?"/>
+            <xsl:variable name="date"
+                          select="string(cit:CI_Date/cit:date/gco:DateTime)"/>
+
+            <xsl:variable name="zuluDate"
+                          select="date-util:convertToISOZuluDateTime($date)"/>
+            <xsl:if test="$zuluDate != ''">
+              <recordDate type="object">
+                {"type": "<xsl:value-of select="$dateType"/>", "date": "<xsl:value-of select="$zuluDate"/>"}
+              </recordDate>
+            </xsl:if>
+      </xsl:for-each>
 
 
       <!-- Indexing resource information

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -254,6 +254,17 @@
                                 $fieldName, ., $allLanguages)"/>
       </xsl:for-each-group>
 
+      <xsl:for-each select="gmd:dateStamp">
+            <xsl:variable name="date"
+                          select="string(gco:DateTime)"/>
+            <xsl:variable name="zuluDate"
+                          select="date-util:convertToISOZuluDateTime($date)"/>
+            <xsl:if test="$zuluDate != ''">
+              <recordDate type="object">
+                {"type": "creation", "date": "<xsl:value-of select="$zuluDate"/>"}
+              </recordDate>
+            </xsl:if>
+      </xsl:for-each>
 
       <!-- Indexing resource information
       TODO: Should we support multiple identification in the same record
@@ -326,6 +337,7 @@
               </resourceDate>
             </xsl:if>
           </xsl:for-each>
+
 
           <xsl:if test="$useDateAsTemporalExtent">
             <xsl:for-each-group select="gmd:date/gmd:CI_Date[gn-fn-index:is-isoDate(gmd:date/*/text())]/gmd:date/*/text()"

--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1902,6 +1902,17 @@
           }
         }
       },
+      "recordDate": {
+        "type": "nested",
+        "properties": {
+          "type": {
+            "type": "keyword"
+          },
+          "date": {
+            "type": "date"
+          }
+        }
+      },
       "specificationConformance": {
         "type": "nested",
         "properties": {


### PR DESCRIPTION
Add a new entry in the Elasticsearch index to capture record dates from metadata information, which was previously missing.

Added recordDate field extraction for ISO19115-3.2018 records from dateInfo
Added recordDate field extraction for ISO19139 records from dateStamp

tested and working with 4.4.12